### PR TITLE
Initialize Java 21 lobby plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Build with Maven
+        run: mvn -B package

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/
+*.iml
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# HeneriaLobby_pheonix
+# HeneriaLobby
+
+Plugin de lobby central pour le réseau Heneria.
+
+## Compilation
+
+Ce projet nécessite Java 21 et Maven.
+
+```sh
+mvn package
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,77 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>net.heneria</groupId>
+    <artifactId>HeneriaLobby</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>papermc-repo</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.velocitypowered</groupId>
+            <artifactId>velocity-api</artifactId>
+            <version>3.2.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.velocitypowered</pattern>
+                                    <shadedPattern>net.heneria.libs.velocity</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
+++ b/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
@@ -1,0 +1,44 @@
+package net.heneria.henerialobby;
+
+import com.google.common.io.ByteStreams;
+import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
+import me.clip.placeholderapi.PlaceholderAPI;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class HeneriaLobby extends JavaPlugin {
+
+    private static final MinecraftChannelIdentifier VELOCITY_CONNECT = MinecraftChannelIdentifier.from("velocity", "connect");
+
+    @Override
+    public void onEnable() {
+        getLogger().info("HeneriaLobby enabled");
+
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            getLogger().info("PlaceholderAPI detected; placeholders enabled");
+        } else {
+            getLogger().warning("PlaceholderAPI not found; placeholders disabled");
+        }
+
+        this.getServer().getMessenger().registerOutgoingPluginChannel(this, VELOCITY_CONNECT.getId());
+    }
+
+    @Override
+    public void onDisable() {
+        this.getServer().getMessenger().unregisterOutgoingPluginChannel(this, VELOCITY_CONNECT.getId());
+    }
+
+    public void sendPlayer(Player player, String server) {
+        var out = ByteStreams.newDataOutput();
+        out.writeUTF(server);
+        player.sendPluginMessage(this, VELOCITY_CONNECT.getId(), out.toByteArray());
+    }
+
+    public String applyPlaceholders(Player player, String text) {
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            return PlaceholderAPI.setPlaceholders(player, text);
+        }
+        return text;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,7 @@
+name: HeneriaLobby
+main: net.heneria.henerialobby.HeneriaLobby
+version: 1.0.0
+api-version: '1.21'
+author: Heneria
+description: Central lobby plugin for the Heneria network
+softdepend: [PlaceholderAPI]


### PR DESCRIPTION
## Summary
- setup Maven project targeting Java 21
- add Paper 1.21, PlaceholderAPI, and Velocity API dependencies
- implement basic lobby plugin skeleton and plugin.yml

## Testing
- `mvn -q package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d337a1a083298296627110d070bb