### PR TITLE
build: add PlaceholderAPI repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,10 @@
             <id>papermc-repo</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
+        <repository>
+            <id>placeholderapi</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
## Summary
- add missing PlaceholderAPI repository so Maven can resolve me.clip:placeholderapi

## Testing
- `mvn -e clean install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d533e13483299f33f276f619de8b