### PR TITLE
fix: use namespaced channel identifier

### DIFF
--- a/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
+++ b/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
@@ -9,7 +9,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 public class HeneriaLobby extends JavaPlugin {
 
-    private static final MinecraftChannelIdentifier VELOCITY_CONNECT = MinecraftChannelIdentifier.from("velocity", "connect");
+    private static final MinecraftChannelIdentifier VELOCITY_CONNECT = MinecraftChannelIdentifier.from("velocity:connect");
 
     @Override
     public void onEnable() {


### PR DESCRIPTION
## Summary
- use namespaced string when creating Velocity connect channel identifier

## Testing
- `mvn -e package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d6593a608329834e22e2bd17d528