### PR TITLE
Add Mojang AuthLib dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,10 @@
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <repository>
+            <id>minecraft-repo</id>
+            <url>https://libraries.minecraft.net/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -40,6 +44,12 @@
             <groupId>com.velocitypowered</groupId>
             <artifactId>velocity-api</artifactId>
             <version>3.2.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mojang</groupId>
+            <artifactId>authlib</artifactId>
+            <version>3.11.50</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
- add Mojang libraries repository and AuthLib dependency

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dc85d7108329ba159d8a94ae286d