### PR TITLE
[CodeFix] #4.1 - Correction du Nom d'Enchantement Déprécié

### DIFF
--- a/src/main/java/net/heneria/henerialobby/selector/ServerSelector.java
+++ b/src/main/java/net/heneria/henerialobby/selector/ServerSelector.java
@@ -139,7 +139,8 @@ public class ServerSelector {
                     .collect(Collectors.toList()));
         }
         if (cs.getBoolean("enchanted", false)) {
-            meta.addEnchant(Enchantment.DURABILITY, 1, true);
+            // Use the modern UNBREAKING enchantment to give the shiny effect without durability tooltip.
+            meta.addEnchant(Enchantment.UNBREAKING, 1, true);
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         }
         item.setItemMeta(meta);


### PR DESCRIPTION
## Summary
- Replace deprecated `Enchantment.DURABILITY` with `Enchantment.UNBREAKING` when giving the shiny effect to selector items
- Ensure enchantment text is hidden while keeping the visual effect

## Testing
- `mvn clean verify` *(fails: The following artifacts could not be resolved: org.apache.maven.plugins:maven-clean-plugin:pom:3.2.0 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ee1549348329a3c0959ede74aa75