### PR TITLE
feat: add lobby protection module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,12 @@
 - Changement de la couleur du titre du menu.
 ### 🛡️ Protections
 - Il est désormais impossible de poser l'item du sélecteur de jeux. L'événement de placement est annulé.
+
+## [1.4.0] - Ajout du Module de Protection
+### ✨ Ajouts
+- Ajout d'un système complet de protection pour les mondes du lobby.
+- Prévention du grief (casse/pose de blocs).
+- Annulation de tous les dégâts aux joueurs et de la perte de faim.
+- Verrouillage de l'inventaire des joueurs.
+- Contrôle de la météo et du cycle jour/nuit.
+- Ajout de la permission `heneria.lobby.bypass.protection` pour les administrateurs.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Plugin de lobby central pour le réseau Heneria.
 * **Système de Spawn :** Définissez un point de spawn unique pour le lobby avec `/setlobby` et permettez aux joueurs d'y retourner avec `/lobby`.
 * **Sélecteur de Serveurs :** Un GUI entièrement personnalisable permet aux joueurs de naviguer facilement entre vos serveurs de jeu.
 * **Protection des Items :** Les items du lobby (comme le sélecteur de jeux) ne peuvent être jetés ni placés.
+* **Protection Complète :** Un module de protection robuste empêche le grief, les dégâts, et verrouille l'inventaire des joueurs pour une expérience propre et sécurisée dans le lobby.
+* **Contrôle de l'Environnement :** Maintient un temps clair et un jour permanent dans les mondes du lobby.
 
 ## Commandes et Permissions
 
@@ -15,6 +17,7 @@ Plugin de lobby central pour le réseau Heneria.
 | `/setlobby` | `heneria.lobby.admin` | Définit le point de spawn du lobby.        |
 | `/lobby`    | (Aucune)              | Téléporte le joueur au spawn.              |
 | `/servers`  | (Aucune)              | Ouvre le menu de sélection des serveurs.   |
+| (Bypass)    | `heneria.lobby.bypass.protection`| Ignore toutes les protections du lobby.   |
 
 ## Dépendances
 

--- a/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
+++ b/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
@@ -7,6 +7,7 @@ import net.heneria.henerialobby.command.SetLobbyCommand;
 import net.heneria.henerialobby.command.ServersCommand;
 import net.heneria.henerialobby.listener.SpawnListener;
 import net.heneria.henerialobby.listener.SelectorListener;
+import net.heneria.henerialobby.listener.ProtectionListener;
 import net.heneria.henerialobby.selector.ServerSelector;
 import net.heneria.henerialobby.spawn.SpawnManager;
 import org.bukkit.Bukkit;
@@ -54,6 +55,9 @@ public class HeneriaLobby extends JavaPlugin {
         getCommand("servers").setExecutor(new ServersCommand(serverSelector));
         Bukkit.getPluginManager().registerEvents(new SpawnListener(this, spawnManager), this);
         Bukkit.getPluginManager().registerEvents(new SelectorListener(this, serverSelector), this);
+        if (getConfig().getBoolean("protection.enabled", true)) {
+            Bukkit.getPluginManager().registerEvents(new ProtectionListener(this), this);
+        }
     }
 
     @Override
@@ -77,6 +81,10 @@ public class HeneriaLobby extends JavaPlugin {
     public String getMessage(String key) {
         String message = messages.getString(key, key);
         return org.bukkit.ChatColor.translateAlternateColorCodes('&', message);
+    }
+
+    public ServerSelector getServerSelector() {
+        return serverSelector;
     }
 }
 

--- a/src/main/java/net/heneria/henerialobby/listener/ProtectionListener.java
+++ b/src/main/java/net/heneria/henerialobby/listener/ProtectionListener.java
@@ -1,0 +1,115 @@
+package net.heneria.henerialobby.listener;
+
+import net.heneria.henerialobby.HeneriaLobby;
+import net.heneria.henerialobby.selector.ServerSelector;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.FoodLevelChangeEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ProtectionListener implements Listener {
+
+    private final HeneriaLobby plugin;
+    private final Set<String> worlds;
+    private final long lockTime;
+    private final ServerSelector selector;
+
+    public ProtectionListener(HeneriaLobby plugin) {
+        this.plugin = plugin;
+        this.worlds = new HashSet<>(plugin.getConfig().getStringList("protection.lobby-worlds"));
+        this.lockTime = plugin.getConfig().getLong("protection.lock-time-to", 6000L);
+        this.selector = plugin.getServerSelector();
+
+        plugin.getServer().getScheduler().runTaskTimer(plugin, () -> {
+            for (String name : worlds) {
+                World world = Bukkit.getWorld(name);
+                if (world != null) {
+                    world.setTime(lockTime);
+                    world.setStorm(false);
+                    world.setThundering(false);
+                }
+            }
+        }, 0L, 100L);
+    }
+
+    private boolean isProtected(World world) {
+        return world != null && worlds.contains(world.getName());
+    }
+
+    private boolean canBypass(Player player) {
+        return player.isOp() || player.hasPermission("heneria.lobby.bypass.protection");
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        plugin.getServer().getScheduler().runTask(plugin, () -> {
+            if (isProtected(player.getWorld()) && !canBypass(player)) {
+                player.setGameMode(GameMode.ADVENTURE);
+            }
+        });
+    }
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        if (isProtected(event.getBlock().getWorld()) && !canBypass(event.getPlayer())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onBlockPlace(BlockPlaceEvent event) {
+        if (isProtected(event.getBlock().getWorld()) && !canBypass(event.getPlayer())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onDamage(EntityDamageEvent event) {
+        if (event.getEntity() instanceof Player player && isProtected(player.getWorld()) && !canBypass(player)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onFoodLevelChange(FoodLevelChangeEvent event) {
+        if (event.getEntity() instanceof Player player && isProtected(player.getWorld()) && !canBypass(player)) {
+            event.setCancelled(true);
+            player.setFoodLevel(20);
+        }
+    }
+
+    @EventHandler
+    public void onDrop(PlayerDropItemEvent event) {
+        Player player = event.getPlayer();
+        if (isProtected(player.getWorld()) && !canBypass(player)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        if (!isProtected(player.getWorld()) || canBypass(player)) {
+            return;
+        }
+        if (selector != null && selector.isMenu(event.getView().getTitle())) {
+            return;
+        }
+        event.setCancelled(true);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,3 +9,15 @@ selector-item:
     - '&7Ouvre le menu pour choisir ton jeu !'
   # Texture Base64 pour la tête "Terre"
   texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6InRlc3QifX19"
+
+protection:
+  # Activer ou désactiver toutes les protections du lobby
+  enabled: true
+
+  # Les protections ne seront actives que dans les mondes listés ici
+  lobby-worlds:
+    - 'lobby'
+    - 'world'
+
+  # Bloquer le temps à une valeur fixe (6000 = midi)
+  lock-time-to: 6000


### PR DESCRIPTION
## Summary
- secure lobby worlds by canceling damage, hunger, block changes and inventory actions
- force players to adventure mode and lock weather & time
- document new bypass permission and protection features

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9efeb27488329a7570e8033c17fb7