### PR TITLE
feat: add configurable join effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.9.0] - Ajout des Effets de Connexion
+### ✨ Ajouts
+- Ajout d'un système d'effets de connexion (sons, particules, feux d'artifice) basé sur les permissions.
+- Création du fichier de configuration `joineffects.yml` pour définir les différents effets et leur priorité.
+- Ajout de permissions de type `heneria.lobby.joineffect.<nom>` pour attribuer les effets.
+
 ## [1.1.0] - Ajout du Sélecteur de Serveurs
 ### ✨ Ajouts
 - Implémentation du GUI de sélection des serveurs, entièrement configurable via `server-selector.yml`.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Plugin de lobby central pour le réseau Heneria.
 * **Contrôle de l'Environnement :** Maintient un temps clair et un jour permanent dans les mondes du lobby.
 * **Affichages Personnalisés :** Configurez un scoreboard et une Tablist uniques avec des informations dynamiques. Le scoreboard est conçu pour afficher le rang (via LuckPerms), les monnaies, et le nombre total de joueurs sur le réseau.
 * **Interactivité :** Améliorez l'expérience des joueurs avec des plaques de saut, un sélecteur de visibilité et des messages de bienvenue personnalisés.
+* **Effets de Connexion :** Offrez des effets cosmétiques (sons, particules, feux d'artifice) uniques aux joueurs à leur connexion, avec des effets différents pour chaque grade.
 
 ## Commandes et Permissions
 
@@ -21,6 +22,7 @@ Plugin de lobby central pour le réseau Heneria.
 | `/servers`  | (Aucune)              | Ouvre le menu de sélection des serveurs.   |
 | (Bypass)    | `heneria.lobby.bypass.protection`| Ignore toutes les protections du lobby.   |
 | (Visibilité)| `heneria.lobby.canbeseen`        | Permet d'être vu par les autres joueurs en mode "VIPs". |
+| (Effets)    | `heneria.lobby.joineffect.<nom>` | Déclenche l'effet de connexion `<nom>`.        |
 
 ## Dépendances
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>net.heneria</groupId>
     <artifactId>HeneriaLobby</artifactId>
-    <version>1.6.0</version>
+    <version>1.9.0</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
+++ b/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
@@ -14,11 +14,13 @@ import net.heneria.henerialobby.listener.DisplayListener;
 import net.heneria.henerialobby.listener.VisibilityListener;
 import net.heneria.henerialobby.listener.LaunchpadListener;
 import net.heneria.henerialobby.listener.JoinLeaveListener;
+import net.heneria.henerialobby.listener.JoinEffectsListener;
 import net.heneria.henerialobby.scoreboard.ScoreboardManager;
 import net.heneria.henerialobby.tablist.TablistManager;
 import net.heneria.henerialobby.selector.ServerSelector;
 import net.heneria.henerialobby.spawn.SpawnManager;
 import net.heneria.henerialobby.visibility.VisibilityManager;
+import net.heneria.henerialobby.joineffects.JoinEffectsManager;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandMap;
@@ -49,6 +51,7 @@ public class HeneriaLobby extends JavaPlugin {
     private ScoreboardManager scoreboardManager;
     private TablistManager tablistManager;
     private VisibilityManager visibilityManager;
+    private JoinEffectsManager joinEffectsManager;
     private java.util.Set<String> lobbyWorlds;
     private final java.util.Map<String, Command> customCommands = new java.util.HashMap<>();
 
@@ -61,11 +64,13 @@ public class HeneriaLobby extends JavaPlugin {
         saveResource("server-selector.yml", false);
         saveResource("scoreboard.yml", false);
         saveResource("commands.yml", false);
+        saveResource("joineffects.yml", false);
         messages = YamlConfiguration.loadConfiguration(new File(getDataFolder(), "messages.yml"));
         scoreboardConfig = YamlConfiguration.loadConfiguration(new File(getDataFolder(), "scoreboard.yml"));
         spawnManager = new SpawnManager(this);
         serverSelector = new ServerSelector(this);
         lobbyWorlds = new java.util.HashSet<>(getConfig().getStringList("lobby-worlds"));
+        joinEffectsManager = new JoinEffectsManager(this);
 
         if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
             getLogger().info("PlaceholderAPI detected; placeholders enabled");
@@ -96,6 +101,7 @@ public class HeneriaLobby extends JavaPlugin {
         if (getConfig().getBoolean("player-experience.join-leave-messages.enabled", true)) {
             Bukkit.getPluginManager().registerEvents(new JoinLeaveListener(this), this);
         }
+        Bukkit.getPluginManager().registerEvents(new JoinEffectsListener(joinEffectsManager), this);
 
         if (getConfig().getBoolean("scoreboard.enabled", true)) {
             scoreboardManager = new ScoreboardManager(this, scoreboardConfig);
@@ -165,6 +171,7 @@ public class HeneriaLobby extends JavaPlugin {
         spawnManager = new SpawnManager(this);
         serverSelector = new ServerSelector(this);
         lobbyWorlds = new java.util.HashSet<>(getConfig().getStringList("lobby-worlds"));
+        joinEffectsManager = new JoinEffectsManager(this);
 
         getCommand("lobby").setExecutor(new LobbyCommand(this, spawnManager));
         getCommand("setlobby").setExecutor(new SetLobbyCommand(this, spawnManager));
@@ -207,6 +214,7 @@ public class HeneriaLobby extends JavaPlugin {
         if (getConfig().getBoolean("player-experience.join-leave-messages.enabled", true)) {
             Bukkit.getPluginManager().registerEvents(new JoinLeaveListener(this), this);
         }
+        Bukkit.getPluginManager().registerEvents(new JoinEffectsListener(joinEffectsManager), this);
 
         loadCustomCommands();
     }

--- a/src/main/java/net/heneria/henerialobby/joineffects/JoinEffectsManager.java
+++ b/src/main/java/net/heneria/henerialobby/joineffects/JoinEffectsManager.java
@@ -1,0 +1,139 @@
+package net.heneria.henerialobby.joineffects;
+
+import net.heneria.henerialobby.HeneriaLobby;
+import org.bukkit.DyeColor;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.entity.Firework;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.meta.FireworkMeta;
+import org.bukkit.Color;
+import org.bukkit.FireworkEffect;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Loads and plays join effects based on permissions.
+ */
+public class JoinEffectsManager {
+
+    private final HeneriaLobby plugin;
+    private final File configFile;
+    private FileConfiguration config;
+    private final List<JoinEffect> effects = new ArrayList<>();
+
+    public JoinEffectsManager(HeneriaLobby plugin) {
+        this.plugin = plugin;
+        this.configFile = new File(plugin.getDataFolder(), "joineffects.yml");
+        reload();
+    }
+
+    public void reload() {
+        config = YamlConfiguration.loadConfiguration(configFile);
+        effects.clear();
+        for (String key : config.getKeys(false)) {
+            ConfigurationSection sec = config.getConfigurationSection(key);
+            if (sec == null) {
+                continue;
+            }
+            JoinEffect effect = new JoinEffect();
+            effect.permission = sec.getString("permission", "");
+            effect.priority = sec.getInt("priority", 0);
+
+            for (String s : sec.getStringList("sounds")) {
+                String[] parts = s.split(",");
+                try {
+                    Sound sound = Sound.valueOf(parts[0]);
+                    float volume = parts.length > 1 ? Float.parseFloat(parts[1]) : 1f;
+                    float pitch = parts.length > 2 ? Float.parseFloat(parts[2]) : 1f;
+                    effect.sounds.add(new SoundEffect(sound, volume, pitch));
+                } catch (Exception ignored) {
+                }
+            }
+
+            for (String p : sec.getStringList("particles")) {
+                String[] parts = p.split(",");
+                try {
+                    Particle particle = Particle.valueOf(parts[0]);
+                    int count = parts.length > 1 ? Integer.parseInt(parts[1]) : 1;
+                    double radius = parts.length > 2 ? Double.parseDouble(parts[2]) : 0;
+                    effect.particles.add(new ParticleEffect(particle, count, radius));
+                } catch (Exception ignored) {
+                }
+            }
+
+            ConfigurationSection fwSec = sec.getConfigurationSection("firework");
+            if (fwSec != null && fwSec.getBoolean("enabled", false)) {
+                FireworkSettings fw = new FireworkSettings();
+                fw.enabled = true;
+                fw.power = fwSec.getInt("power", 1);
+                for (String colorName : fwSec.getStringList("colors")) {
+                    try {
+                        fw.colors.add(DyeColor.valueOf(colorName.toUpperCase()).getColor());
+                    } catch (Exception ignored) {
+                    }
+                }
+                effect.firework = fw;
+            }
+
+            effects.add(effect);
+        }
+    }
+
+    public void play(Player player) {
+        JoinEffect selected = null;
+        for (JoinEffect effect : effects) {
+            if (effect.permission.isEmpty() || !player.hasPermission(effect.permission)) {
+                continue;
+            }
+            if (selected == null || effect.priority > selected.priority) {
+                selected = effect;
+            }
+        }
+        if (selected == null) {
+            return;
+        }
+        Location loc = player.getLocation();
+        for (SoundEffect s : selected.sounds) {
+            player.playSound(loc, s.sound, s.volume, s.pitch);
+        }
+        for (ParticleEffect p : selected.particles) {
+            loc.getWorld().spawnParticle(p.particle, loc, p.count, p.radius, p.radius, p.radius);
+        }
+        if (selected.firework != null && selected.firework.enabled) {
+            Firework fw = loc.getWorld().spawn(loc, Firework.class);
+            FireworkMeta meta = fw.getFireworkMeta();
+            meta.setPower(selected.firework.power);
+            FireworkEffect.Builder builder = FireworkEffect.builder();
+            builder.withColor(selected.firework.colors);
+            meta.addEffect(builder.build());
+            fw.setFireworkMeta(meta);
+        }
+    }
+
+    private static class JoinEffect {
+        String permission;
+        int priority;
+        List<SoundEffect> sounds = new ArrayList<>();
+        List<ParticleEffect> particles = new ArrayList<>();
+        FireworkSettings firework;
+    }
+
+    private record SoundEffect(Sound sound, float volume, float pitch) {
+    }
+
+    private record ParticleEffect(Particle particle, int count, double radius) {
+    }
+
+    private static class FireworkSettings {
+        boolean enabled;
+        int power;
+        List<Color> colors = new ArrayList<>();
+    }
+}

--- a/src/main/java/net/heneria/henerialobby/listener/JoinEffectsListener.java
+++ b/src/main/java/net/heneria/henerialobby/listener/JoinEffectsListener.java
@@ -1,0 +1,21 @@
+package net.heneria.henerialobby.listener;
+
+import net.heneria.henerialobby.joineffects.JoinEffectsManager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+public class JoinEffectsListener implements Listener {
+
+    private final JoinEffectsManager manager;
+
+    public JoinEffectsListener(JoinEffectsManager manager) {
+        this.manager = manager;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onJoin(PlayerJoinEvent event) {
+        manager.play(event.getPlayer());
+    }
+}

--- a/src/main/resources/joineffects.yml
+++ b/src/main/resources/joineffects.yml
@@ -1,0 +1,36 @@
+# Configurez ici les différents effets de connexion.
+# Le plugin choisira l'effet avec la plus HAUTE priorité que le joueur possède.
+
+vip:
+  permission: "heneria.lobby.joineffect.vip"
+  priority: 10
+  sounds:
+    - "ENTITY_PLAYER_LEVELUP,1,1.2" # Format: SOUND_NAME,volume,pitch
+  particles:
+    - "VILLAGER_HAPPY,50,0.5" # Format: PARTICLE_NAME,count,radius
+  firework:
+    enabled: false
+
+mvp:
+  permission: "heneria.lobby.joineffect.mvp"
+  priority: 20
+  sounds:
+    - "ENTITY_ENDER_DRAGON_FLAP,1,1"
+    - "BLOCK_BEACON_ACTIVATE,0.8,1.5"
+  particles:
+    - "ENCHANTMENT_TABLE,100,1"
+    - "PORTAL,150,1.2"
+  firework:
+    enabled: true
+    power: 1
+    colors: ["AQUA", "LIME"]
+
+staff:
+  permission: "heneria.lobby.joineffect.staff"
+  priority: 100
+  sounds:
+    - "BLOCK_END_PORTAL_SPAWN,1,1"
+  particles:
+    - "TOTEM,50,0.8"
+  firework:
+    enabled: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: HeneriaLobby
 main: net.heneria.henerialobby.HeneriaLobby
-version: 1.6.0
+version: 1.9.0
 api-version: '1.21'
 author: Heneria
 description: Central lobby plugin for the Heneria network


### PR DESCRIPTION
## Summary
- add join effects manager and listener to play sounds, particles and fireworks based on permissions
- save default `joineffects.yml` and wire into plugin
- document join effects and bump version to 1.9.0

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fc867f608329bfac76ac55ae28d3