### PR TITLE
feat: add armor stand based npc system

### DIFF
--- a/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
+++ b/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
@@ -25,6 +25,9 @@ import net.heneria.henerialobby.visibility.VisibilityManager;
 import net.heneria.henerialobby.joineffects.JoinEffectsManager;
 import net.heneria.henerialobby.announcer.Announcer;
 import net.heneria.henerialobby.hologram.HologramManager;
+import net.heneria.henerialobby.npc.NPCManager;
+import net.heneria.henerialobby.npc.NPCCommand;
+import net.heneria.henerialobby.npc.NPCListener;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandMap;
@@ -58,6 +61,7 @@ public class HeneriaLobby extends JavaPlugin {
     private JoinEffectsManager joinEffectsManager;
     private Announcer announcer;
     private HologramManager hologramManager;
+    private NPCManager npcManager;
     private java.util.Set<String> lobbyWorlds;
     private final java.util.Map<String, Command> customCommands = new java.util.HashMap<>();
 
@@ -73,6 +77,8 @@ public class HeneriaLobby extends JavaPlugin {
         saveResource("joineffects.yml", false);
         saveResource("announcer.yml", false);
         saveResource("holograms.yml", false);
+        saveResource("npcs.yml", false);
+        saveResource("npc-actions.yml", false);
         messages = YamlConfiguration.loadConfiguration(new File(getDataFolder(), "messages.yml"));
         scoreboardConfig = YamlConfiguration.loadConfiguration(new File(getDataFolder(), "scoreboard.yml"));
         spawnManager = new SpawnManager(this);
@@ -97,6 +103,9 @@ public class HeneriaLobby extends JavaPlugin {
         getCommand("lobbyadmin").setExecutor(new LobbyAdminCommand(this));
         hologramManager = new HologramManager(this);
         getCommand("hologram").setExecutor(new HologramCommand(hologramManager));
+        npcManager = new NPCManager(this);
+        getCommand("npc").setExecutor(new NPCCommand(npcManager));
+        Bukkit.getPluginManager().registerEvents(new NPCListener(npcManager), this);
         Bukkit.getPluginManager().registerEvents(new SpawnListener(this, spawnManager), this);
         Bukkit.getPluginManager().registerEvents(new SelectorListener(this, serverSelector), this);
         if (getConfig().getBoolean("protection.enabled", true)) {
@@ -139,9 +148,13 @@ public class HeneriaLobby extends JavaPlugin {
           unregisterCustomCommands();
           this.getServer().getMessenger().unregisterOutgoingPluginChannel(this, VELOCITY_CONNECT);
           if (hologramManager != null) {
-              hologramManager.saveAll();
-              hologramManager.removeAll();
-          }
+            hologramManager.saveAll();
+            hologramManager.removeAll();
+        }
+        if (npcManager != null) {
+            npcManager.saveAll();
+            npcManager.removeAll();
+        }
       }
 
     public void sendPlayer(Player player, String server) {
@@ -196,6 +209,8 @@ public class HeneriaLobby extends JavaPlugin {
         getCommand("lobby").setExecutor(new LobbyCommand(this, spawnManager));
         getCommand("setlobby").setExecutor(new SetLobbyCommand(this, spawnManager));
         getCommand("servers").setExecutor(new ServersCommand(serverSelector));
+        npcManager = new NPCManager(this);
+        getCommand("npc").setExecutor(new NPCCommand(npcManager));
 
         org.bukkit.Bukkit.getScheduler().cancelTasks(this);
         HandlerList.unregisterAll(this);
@@ -238,6 +253,7 @@ public class HeneriaLobby extends JavaPlugin {
         }
         Bukkit.getPluginManager().registerEvents(new JoinEffectsListener(joinEffectsManager), this);
         Bukkit.getPluginManager().registerEvents(new InterfaceChatListener(this), this);
+        Bukkit.getPluginManager().registerEvents(new NPCListener(npcManager), this);
 
         hologramManager = new HologramManager(this);
         getCommand("hologram").setExecutor(new HologramCommand(hologramManager));

--- a/src/main/java/net/heneria/henerialobby/npc/NPC.java
+++ b/src/main/java/net/heneria/henerialobby/npc/NPC.java
@@ -1,0 +1,25 @@
+package net.heneria.henerialobby.npc;
+
+import org.bukkit.entity.ArmorStand;
+
+/**
+ * Simple container representing a managed NPC backed by an ArmorStand.
+ */
+public class NPC {
+
+    private final String name;
+    private final ArmorStand stand;
+
+    public NPC(String name, ArmorStand stand) {
+        this.name = name;
+        this.stand = stand;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ArmorStand getStand() {
+        return stand;
+    }
+}

--- a/src/main/java/net/heneria/henerialobby/npc/NPCCommand.java
+++ b/src/main/java/net/heneria/henerialobby/npc/NPCCommand.java
@@ -1,0 +1,160 @@
+package net.heneria.henerialobby.npc;
+
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Arrays;
+
+/**
+ * Handles the /npc command and its subcommands.
+ */
+public class NPCCommand implements CommandExecutor {
+
+    private final NPCManager manager;
+
+    public NPCCommand(NPCManager manager) {
+        this.manager = manager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Player only");
+            return true;
+        }
+        if (!player.hasPermission("heneria.lobby.admin.npc")) {
+            player.sendMessage("§cVous n'avez pas la permission.");
+            return true;
+        }
+        if (args.length == 0) {
+            player.sendMessage("§cUsage: /npc <create|select|sethead|equip|unequip|link>...");
+            return true;
+        }
+        String sub = args[0].toLowerCase();
+        switch (sub) {
+            case "create":
+                if (args.length < 2) {
+                    player.sendMessage("§cUsage: /npc create <name>");
+                    return true;
+                }
+                String name = args[1];
+                if (manager.create(name, player.getLocation())) {
+                    player.sendMessage("§aNPC créé.");
+                } else {
+                    player.sendMessage("§cUn NPC avec ce nom existe déjà.");
+                }
+                return true;
+            case "select":
+                if (args.length < 2) {
+                    player.sendMessage("§cUsage: /npc select <name>");
+                    return true;
+                }
+                NPC npc = manager.getNPC(args[1]);
+                if (npc == null) {
+                    player.sendMessage("§cNPC introuvable.");
+                } else {
+                    manager.select(player, npc);
+                    player.sendMessage("§aNPC sélectionné: " + npc.getName());
+                }
+                return true;
+            case "sethead":
+                if (args.length < 2) {
+                    player.sendMessage("§cUsage: /npc sethead <player|hdb:id>");
+                    return true;
+                }
+                npc = manager.getSelected(player);
+                if (npc == null) {
+                    player.sendMessage("§cAucun NPC sélectionné.");
+                    return true;
+                }
+                ItemStack head = manager.createHead(args[1]);
+                if (head == null) {
+                    player.sendMessage("§cTête introuvable.");
+                    return true;
+                }
+                if (npc.getStand().getEquipment() != null) {
+                    npc.getStand().getEquipment().setHelmet(head);
+                    manager.saveAll();
+                    player.sendMessage("§aTête définie.");
+                }
+                return true;
+            case "equip":
+                npc = manager.getSelected(player);
+                if (npc == null) {
+                    player.sendMessage("§cAucun NPC sélectionné.");
+                    return true;
+                }
+                ItemStack item = player.getInventory().getItemInMainHand();
+                if (item == null || item.getType() == Material.AIR) {
+                    player.sendMessage("§cTenez un objet dans votre main.");
+                    return true;
+                }
+                var eq = npc.getStand().getEquipment();
+                if (eq != null) {
+                    String type = item.getType().name();
+                    if (type.endsWith("_HELMET")) {
+                        eq.setHelmet(item.clone());
+                    } else if (type.endsWith("_CHESTPLATE")) {
+                        eq.setChestplate(item.clone());
+                    } else if (type.endsWith("_LEGGINGS")) {
+                        eq.setLeggings(item.clone());
+                    } else if (type.endsWith("_BOOTS")) {
+                        eq.setBoots(item.clone());
+                    } else {
+                        eq.setItemInMainHand(item.clone());
+                    }
+                    manager.saveAll();
+                    player.sendMessage("§aObjet équipé.");
+                }
+                return true;
+            case "unequip":
+                if (args.length < 2) {
+                    player.sendMessage("§cUsage: /npc unequip <helmet|chestplate|leggings|boots|hand|offhand>");
+                    return true;
+                }
+                npc = manager.getSelected(player);
+                if (npc == null) {
+                    player.sendMessage("§cAucun NPC sélectionné.");
+                    return true;
+                }
+                eq = npc.getStand().getEquipment();
+                if (eq != null) {
+                    switch (args[1].toLowerCase()) {
+                        case "helmet": eq.setHelmet(null); break;
+                        case "chestplate": eq.setChestplate(null); break;
+                        case "leggings": eq.setLeggings(null); break;
+                        case "boots": eq.setBoots(null); break;
+                        case "hand": eq.setItemInMainHand(null); break;
+                        case "offhand": eq.setItemInOffHand(null); break;
+                        default:
+                            player.sendMessage("§cSlot invalide.");
+                            return true;
+                    }
+                    manager.saveAll();
+                    player.sendMessage("§aÉquipement retiré.");
+                }
+                return true;
+            case "link":
+                if (args.length < 2) {
+                    player.sendMessage("§cUsage: /npc link <action> [args...]");
+                    return true;
+                }
+                npc = manager.getSelected(player);
+                if (npc == null) {
+                    player.sendMessage("§cAucun NPC sélectionné.");
+                    return true;
+                }
+                String action = String.join(" ", Arrays.copyOfRange(args, 1, args.length));
+                manager.setAction(npc.getName(), action);
+                player.sendMessage("§aAction liée.");
+                return true;
+            default:
+                player.sendMessage("§cUsage: /npc <create|select|sethead|equip|unequip|link>...");
+                return true;
+        }
+    }
+}

--- a/src/main/java/net/heneria/henerialobby/npc/NPCListener.java
+++ b/src/main/java/net/heneria/henerialobby/npc/NPCListener.java
@@ -1,0 +1,34 @@
+package net.heneria.henerialobby.npc;
+
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractAtEntityEvent;
+
+/**
+ * Handles interaction with NPCs.
+ */
+public class NPCListener implements Listener {
+
+    private final NPCManager manager;
+
+    public NPCListener(NPCManager manager) {
+        this.manager = manager;
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractAtEntityEvent event) {
+        if (!(event.getRightClicked() instanceof ArmorStand stand)) return;
+        NPC npc = manager.getNPC(stand.getUniqueId());
+        if (npc == null) return;
+        event.setCancelled(true);
+        Player player = event.getPlayer();
+        if (player.isSneaking() && player.hasPermission("heneria.lobby.admin.npc")) {
+            manager.select(player, npc);
+            player.sendMessage("§aNPC sélectionné: " + npc.getName());
+            return;
+        }
+        manager.executeAction(player, npc.getName());
+    }
+}

--- a/src/main/java/net/heneria/henerialobby/npc/NPCManager.java
+++ b/src/main/java/net/heneria/henerialobby/npc/NPCManager.java
@@ -1,0 +1,225 @@
+package net.heneria.henerialobby.npc;
+
+import net.heneria.henerialobby.HeneriaLobby;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Handles loading, saving and basic manipulation of NPCs.
+ */
+public class NPCManager {
+
+    private final HeneriaLobby plugin;
+    private final Map<String, NPC> npcs = new HashMap<>();
+    private final Map<UUID, NPC> byId = new HashMap<>();
+    private final Map<UUID, NPC> selections = new HashMap<>();
+    private final Map<String, String> actions = new HashMap<>();
+
+    private final File file;
+    private final FileConfiguration config;
+    private final File actionsFile;
+    private final FileConfiguration actionsConfig;
+
+    public NPCManager(HeneriaLobby plugin) {
+        this.plugin = plugin;
+        this.file = new File(plugin.getDataFolder(), "npcs.yml");
+        this.config = YamlConfiguration.loadConfiguration(file);
+        this.actionsFile = new File(plugin.getDataFolder(), "npc-actions.yml");
+        this.actionsConfig = YamlConfiguration.loadConfiguration(actionsFile);
+        loadAll();
+        loadActions();
+    }
+
+    private void loadAll() {
+        npcs.clear();
+        byId.clear();
+        ConfigurationSection root = config.getConfigurationSection("npcs");
+        if (root == null) {
+            return;
+        }
+        for (String key : root.getKeys(false)) {
+            ConfigurationSection sec = root.getConfigurationSection(key);
+            if (sec == null) continue;
+            ConfigurationSection locSec = sec.getConfigurationSection("location");
+            if (locSec == null) continue;
+            String world = locSec.getString("world");
+            double x = locSec.getDouble("x");
+            double y = locSec.getDouble("y");
+            double z = locSec.getDouble("z");
+            float yaw = (float) locSec.getDouble("yaw");
+            var w = Bukkit.getWorld(world);
+            if (w == null) continue;
+            Location loc = new Location(w, x, y, z, yaw, 0f);
+            ArmorStand stand = w.spawn(loc, ArmorStand.class, as -> {
+                as.setGravity(false);
+                as.setBasePlate(false);
+                as.setArms(true);
+                as.setVisible(true);
+                as.setInvulnerable(true);
+                as.setPersistent(true);
+                as.setRemoveWhenFarAway(false);
+                as.setCanPickupItems(false);
+            });
+            ConfigurationSection equipSec = sec.getConfigurationSection("equipment");
+            if (equipSec != null) {
+                var eq = stand.getEquipment();
+                if (eq != null) {
+                    eq.setHelmet(equipSec.getItemStack("helmet"));
+                    eq.setChestplate(equipSec.getItemStack("chestplate"));
+                    eq.setLeggings(equipSec.getItemStack("leggings"));
+                    eq.setBoots(equipSec.getItemStack("boots"));
+                    eq.setItemInMainHand(equipSec.getItemStack("hand"));
+                    eq.setItemInOffHand(equipSec.getItemStack("offhand"));
+                }
+            }
+            NPC npc = new NPC(key, stand);
+            npcs.put(key.toLowerCase(), npc);
+            byId.put(stand.getUniqueId(), npc);
+        }
+    }
+
+    private void loadActions() {
+        actions.clear();
+        ConfigurationSection sec = actionsConfig.getConfigurationSection("actions");
+        if (sec != null) {
+            for (String key : sec.getKeys(false)) {
+                actions.put(key.toLowerCase(), sec.getString(key));
+            }
+        }
+    }
+
+    public void saveAll() {
+        ConfigurationSection root = config.createSection("npcs");
+        for (NPC npc : npcs.values()) {
+            ConfigurationSection sec = root.createSection(npc.getName());
+            ArmorStand stand = npc.getStand();
+            sec.set("uuid", stand.getUniqueId().toString());
+            Location loc = stand.getLocation();
+            sec.set("location.world", loc.getWorld().getName());
+            sec.set("location.x", loc.getX());
+            sec.set("location.y", loc.getY());
+            sec.set("location.z", loc.getZ());
+            sec.set("location.yaw", loc.getYaw());
+            var eq = stand.getEquipment();
+            if (eq != null) {
+                sec.set("equipment.helmet", eq.getHelmet());
+                sec.set("equipment.chestplate", eq.getChestplate());
+                sec.set("equipment.leggings", eq.getLeggings());
+                sec.set("equipment.boots", eq.getBoots());
+                sec.set("equipment.hand", eq.getItemInMainHand());
+                sec.set("equipment.offhand", eq.getItemInOffHand());
+            }
+        }
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            plugin.getLogger().warning("Could not save npcs.yml");
+        }
+        ConfigurationSection act = actionsConfig.createSection("actions");
+        for (Map.Entry<String, String> en : actions.entrySet()) {
+            act.set(en.getKey(), en.getValue());
+        }
+        try {
+            actionsConfig.save(actionsFile);
+        } catch (IOException e) {
+            plugin.getLogger().warning("Could not save npc-actions.yml");
+        }
+    }
+
+    public boolean create(String name, Location loc) {
+        if (npcs.containsKey(name.toLowerCase())) return false;
+        ArmorStand stand = loc.getWorld().spawn(loc, ArmorStand.class, as -> {
+            as.setGravity(false);
+            as.setBasePlate(false);
+            as.setArms(true);
+            as.setVisible(true);
+            as.setInvulnerable(true);
+            as.setPersistent(true);
+            as.setRemoveWhenFarAway(false);
+            as.setCanPickupItems(false);
+        });
+        NPC npc = new NPC(name, stand);
+        npcs.put(name.toLowerCase(), npc);
+        byId.put(stand.getUniqueId(), npc);
+        saveAll();
+        return true;
+    }
+
+    public NPC getNPC(String name) {
+        return npcs.get(name.toLowerCase());
+    }
+
+    public NPC getNPC(UUID uuid) {
+        return byId.get(uuid);
+    }
+
+    public void select(Player player, NPC npc) {
+        selections.put(player.getUniqueId(), npc);
+    }
+
+    public NPC getSelected(Player player) {
+        return selections.get(player.getUniqueId());
+    }
+
+    public ItemStack createHead(String input) {
+        ItemStack head = null;
+        if (input.startsWith("hdb:")) {
+            String id = input.substring(4);
+            try {
+                Class<?> apiClass = Class.forName("me.arcaniax.hdb.api.HeadDatabaseAPI");
+                Object api = apiClass.getDeclaredConstructor().newInstance();
+                head = (ItemStack) apiClass.getMethod("getItemHead", String.class).invoke(api, id);
+            } catch (Exception ignored) {
+            }
+        } else {
+            var item = new org.bukkit.inventory.ItemStack(org.bukkit.Material.PLAYER_HEAD);
+            var meta = (org.bukkit.inventory.meta.SkullMeta) item.getItemMeta();
+            if (meta != null) {
+                meta.setOwningPlayer(Bukkit.getOfflinePlayer(input));
+                item.setItemMeta(meta);
+            }
+            head = item;
+        }
+        return head;
+    }
+
+    public void setAction(String npcName, String action) {
+        actions.put(npcName.toLowerCase(), action);
+        saveAll();
+    }
+
+    public String getAction(String npcName) {
+        return actions.get(npcName.toLowerCase());
+    }
+
+    public void executeAction(Player player, String npcName) {
+        String action = getAction(npcName);
+        if (action == null) return;
+        if (action.toLowerCase().startsWith("runcommand ")) {
+            String cmd = action.substring("runcommand ".length());
+            Bukkit.dispatchCommand(player, cmd.replace("%player%", player.getName()));
+        } else if (action.equalsIgnoreCase("openservermenu")) {
+            plugin.getServerSelector().openMenu(player);
+        }
+    }
+
+    public void removeAll() {
+        for (NPC npc : npcs.values()) {
+            npc.getStand().remove();
+        }
+        npcs.clear();
+        byId.clear();
+    }
+}

--- a/src/main/resources/npc-actions.yml
+++ b/src/main/resources/npc-actions.yml
@@ -1,0 +1,2 @@
+# Actions liées aux PNJ.
+actions: {}

--- a/src/main/resources/npcs.yml
+++ b/src/main/resources/npcs.yml
@@ -1,0 +1,2 @@
+# Ce fichier est géré automatiquement par les commandes /npc.
+npcs: {}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -24,6 +24,10 @@ commands:
     description: "Gestion des hologrammes"
     usage: "/hologram <create|delete|addline|setline|movehere>"
     permission: heneria.lobby.admin.hologram
+  npc:
+    description: "Gestion des PNJ"
+    usage: "/npc <create|select|sethead|equip|unequip|link>"
+    permission: heneria.lobby.admin.npc
 permissions:
   heneria.lobby.admin:
     description: "Permet de configurer le spawn du lobby"
@@ -39,4 +43,7 @@ permissions:
     default: false
   heneria.lobby.admin.hologram:
     description: "Permet de gérer les hologrammes"
+    default: op
+  heneria.lobby.admin.npc:
+    description: "Permet de gérer les PNJ"
     default: op


### PR DESCRIPTION
## Summary
- add NPC manager with YAML persistence and equipment serialization
- introduce `/npc` admin command for creating and customizing ArmorStand NPCs
- hook NPC interactions to configurable actions

## Testing
- `mvn -q -e package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1b3445908329a5ae3bd731360330