### PR TITLE
fix: resolve wildcard generic usage in InterfaceChatListener

### DIFF
--- a/src/main/java/net/heneria/henerialobby/listener/InterfaceChatListener.java
+++ b/src/main/java/net/heneria/henerialobby/listener/InterfaceChatListener.java
@@ -15,6 +15,7 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.title.Title;
 import net.kyori.adventure.title.TitlePart;
 import java.time.Duration;
+import java.util.Objects;
 
 public class InterfaceChatListener implements Listener {
 
@@ -48,7 +49,7 @@ public class InterfaceChatListener implements Listener {
             java.util.List<java.util.Map<?, ?>> subs = section.getMapList("subtitles");
             long delay = 0L;
             for (java.util.Map<?, ?> map : subs) {
-                String text = plugin.applyPlaceholders(player, String.valueOf(map.getOrDefault("text", "")));
+                String text = plugin.applyPlaceholders(player, Objects.toString(map.get("text"), ""));
                 Component subComp = mm.deserialize(text);
                 double fi = map.get("fade-in") instanceof Number ? ((Number) map.get("fade-in")).doubleValue() : 0D;
                 double st = map.get("stay") instanceof Number ? ((Number) map.get("stay")).doubleValue() : 0D;


### PR DESCRIPTION
## Summary
- avoid `Map#getOrDefault` wildcard generic issue when parsing subtitle text
- import `Objects` for null-safe subtitle text handling

## Testing
- `mvn -q -e package` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb225d9afc8329a6473249e6ca7b85