### PR TITLE
feat: improve NPC admin commands

### DIFF
--- a/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
+++ b/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
@@ -104,7 +104,9 @@ public class HeneriaLobby extends JavaPlugin {
         hologramManager = new HologramManager(this);
         getCommand("hologram").setExecutor(new HologramCommand(hologramManager));
         npcManager = new NPCManager(this);
-        getCommand("npc").setExecutor(new NPCCommand(npcManager));
+        NPCCommand npcCommand = new NPCCommand(npcManager);
+        getCommand("npc").setExecutor(npcCommand);
+        getCommand("npc").setTabCompleter(npcCommand);
         Bukkit.getPluginManager().registerEvents(new NPCListener(npcManager), this);
         Bukkit.getPluginManager().registerEvents(new SpawnListener(this, spawnManager), this);
         Bukkit.getPluginManager().registerEvents(new SelectorListener(this, serverSelector), this);
@@ -210,7 +212,9 @@ public class HeneriaLobby extends JavaPlugin {
         getCommand("setlobby").setExecutor(new SetLobbyCommand(this, spawnManager));
         getCommand("servers").setExecutor(new ServersCommand(serverSelector));
         npcManager = new NPCManager(this);
-        getCommand("npc").setExecutor(new NPCCommand(npcManager));
+        NPCCommand npcCommand = new NPCCommand(npcManager);
+        getCommand("npc").setExecutor(npcCommand);
+        getCommand("npc").setTabCompleter(npcCommand);
 
         org.bukkit.Bukkit.getScheduler().cancelTasks(this);
         HandlerList.unregisterAll(this);

--- a/src/main/java/net/heneria/henerialobby/npc/NPCManager.java
+++ b/src/main/java/net/heneria/henerialobby/npc/NPCManager.java
@@ -204,6 +204,33 @@ public class NPCManager {
         return actions.get(npcName.toLowerCase());
     }
 
+    /**
+     * Deletes an NPC by name and removes all associated data.
+     *
+     * @param name the NPC name
+     * @return true if the NPC existed and was removed
+     */
+    public boolean delete(String name) {
+        NPC npc = npcs.remove(name.toLowerCase());
+        if (npc == null) {
+            return false;
+        }
+        byId.remove(npc.getStand().getUniqueId());
+        actions.remove(name.toLowerCase());
+        // remove selections pointing to this NPC
+        selections.values().removeIf(n -> n == npc);
+        npc.getStand().remove();
+        saveAll();
+        return true;
+    }
+
+    /**
+     * Returns a set of all NPC names.
+     */
+    public java.util.Set<String> getNames() {
+        return new java.util.HashSet<>(npcs.keySet());
+    }
+
     public void executeAction(Player player, String npcName) {
         String action = getAction(npcName);
         if (action == null) return;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -26,7 +26,7 @@ commands:
     permission: heneria.lobby.admin.hologram
   npc:
     description: "Gestion des PNJ"
-    usage: "/npc <create|select|sethead|equip|unequip|link>"
+    usage: "/npc <create|delete|select|move|skin|equip|unequip|link|help>"
     permission: heneria.lobby.admin.npc
 permissions:
   heneria.lobby.admin:


### PR DESCRIPTION
## Summary
- add help and standardized feedback for /npc commands
- support deleting and moving NPCs, updating skins, and more
- implement tab completion for NPC management commands

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2316b7ec83298767383afb79f25f