### PR TITLE
feat: improve hologram command ergonomics

### DIFF
--- a/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
+++ b/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
@@ -102,7 +102,9 @@ public class HeneriaLobby extends JavaPlugin {
         getCommand("servers").setExecutor(new ServersCommand(serverSelector));
         getCommand("lobbyadmin").setExecutor(new LobbyAdminCommand(this));
         hologramManager = new HologramManager(this);
-        getCommand("hologram").setExecutor(new HologramCommand(hologramManager));
+        HologramCommand hologramCommand = new HologramCommand(hologramManager);
+        getCommand("hologram").setExecutor(hologramCommand);
+        getCommand("hologram").setTabCompleter(hologramCommand);
         npcManager = new NPCManager(this);
         NPCCommand npcCommand = new NPCCommand(npcManager);
         getCommand("npc").setExecutor(npcCommand);
@@ -260,7 +262,9 @@ public class HeneriaLobby extends JavaPlugin {
         Bukkit.getPluginManager().registerEvents(new NPCListener(npcManager), this);
 
         hologramManager = new HologramManager(this);
-        getCommand("hologram").setExecutor(new HologramCommand(hologramManager));
+        HologramCommand hologramCommand = new HologramCommand(hologramManager);
+        getCommand("hologram").setExecutor(hologramCommand);
+        getCommand("hologram").setTabCompleter(hologramCommand);
 
         loadCustomCommands();
     }

--- a/src/main/java/net/heneria/henerialobby/command/HologramCommand.java
+++ b/src/main/java/net/heneria/henerialobby/command/HologramCommand.java
@@ -5,17 +5,38 @@ import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
+import org.bukkit.util.StringUtil;
+
+import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * Command allowing administrators to manage holograms.
  */
-public class HologramCommand implements CommandExecutor {
+public class HologramCommand implements CommandExecutor, TabCompleter {
+
+    private static final String PREFIX_SUCCESS = "§a[Succès] §f";
+    private static final String PREFIX_ERROR = "§c[Erreur] §f";
+    private static final String PREFIX_INFO = "§e[Info] §f";
 
     private final HologramManager manager;
 
     public HologramCommand(HologramManager manager) {
         this.manager = manager;
+    }
+
+    private void success(Player player, String msg) {
+        player.sendMessage(PREFIX_SUCCESS + msg);
+    }
+
+    private void error(Player player, String msg) {
+        player.sendMessage(PREFIX_ERROR + msg);
+    }
+
+    private void info(Player player, String msg) {
+        player.sendMessage(PREFIX_INFO + msg);
     }
 
     @Override
@@ -25,55 +46,58 @@ public class HologramCommand implements CommandExecutor {
             return true;
         }
         if (!player.hasPermission("heneria.lobby.admin.hologram")) {
-            player.sendMessage("§cVous n'avez pas la permission.");
+            error(player, "Vous n'avez pas la permission.");
             return true;
         }
         if (args.length == 0) {
-            player.sendMessage("§cUsage: /hologram <create|delete|addline|setline|movehere>...");
+            info(player, "Utilisez /hologram help pour la liste des commandes.");
             return true;
         }
-        String sub = args[0].toLowerCase();
+        String sub = args[0].toLowerCase(Locale.ROOT);
         switch (sub) {
+            case "help":
+                sendHelp(player);
+                return true;
             case "create":
                 if (args.length < 3) {
-                    player.sendMessage("§cUsage: /hologram create <name> <text>");
+                    error(player, "Usage: /hologram create <name> <text>");
                     return true;
                 }
                 String name = args[1];
-                String text = String.join(" ", java.util.Arrays.copyOfRange(args, 2, args.length));
+                String text = String.join(" ", Arrays.copyOfRange(args, 2, args.length));
                 if (manager.create(name, player.getLocation(), text)) {
-                    player.sendMessage("§aHologramme créé.");
+                    success(player, "Hologramme créé.");
                 } else {
-                    player.sendMessage("§cUn hologramme avec ce nom existe déjà.");
+                    error(player, "Un hologramme avec ce nom existe déjà.");
                 }
                 return true;
             case "delete":
                 if (args.length < 2) {
-                    player.sendMessage("§cUsage: /hologram delete <name>");
+                    error(player, "Usage: /hologram delete <name>");
                     return true;
                 }
                 if (manager.delete(args[1])) {
-                    player.sendMessage("§aHologramme supprimé.");
+                    success(player, "Hologramme supprimé.");
                 } else {
-                    player.sendMessage("§cHologramme introuvable.");
+                    error(player, "Hologramme introuvable.");
                 }
                 return true;
             case "addline":
                 if (args.length < 3) {
-                    player.sendMessage("§cUsage: /hologram addline <name> <text>");
+                    error(player, "Usage: /hologram addline <name> <text>");
                     return true;
                 }
                 name = args[1];
-                text = String.join(" ", java.util.Arrays.copyOfRange(args, 2, args.length));
+                text = String.join(" ", Arrays.copyOfRange(args, 2, args.length));
                 if (manager.addLine(name, text)) {
-                    player.sendMessage("§aLigne ajoutée.");
+                    success(player, "Ligne ajoutée.");
                 } else {
-                    player.sendMessage("§cHologramme introuvable.");
+                    error(player, "Hologramme introuvable.");
                 }
                 return true;
             case "setline":
                 if (args.length < 4) {
-                    player.sendMessage("§cUsage: /hologram setline <name> <number> <text>");
+                    error(player, "Usage: /hologram setline <name> <number> <text>");
                     return true;
                 }
                 name = args[1];
@@ -81,32 +105,64 @@ public class HologramCommand implements CommandExecutor {
                 try {
                     index = Integer.parseInt(args[2]) - 1;
                 } catch (NumberFormatException e) {
-                    player.sendMessage("§cNuméro invalide.");
+                    error(player, "Numéro invalide.");
                     return true;
                 }
-                text = String.join(" ", java.util.Arrays.copyOfRange(args, 3, args.length));
+                text = String.join(" ", Arrays.copyOfRange(args, 3, args.length));
                 if (manager.setLine(name, index, text)) {
-                    player.sendMessage("§aLigne modifiée.");
+                    success(player, "Ligne modifiée.");
                 } else {
-                    player.sendMessage("§cHologramme ou ligne introuvable.");
+                    error(player, "Hologramme ou ligne introuvable.");
                 }
                 return true;
             case "movehere":
                 if (args.length < 2) {
-                    player.sendMessage("§cUsage: /hologram movehere <name>");
+                    error(player, "Usage: /hologram movehere <name>");
                     return true;
                 }
                 name = args[1];
                 Location loc = player.getLocation();
                 if (manager.move(name, loc)) {
-                    player.sendMessage("§aHologramme déplacé.");
+                    success(player, "Hologramme déplacé.");
                 } else {
-                    player.sendMessage("§cHologramme introuvable.");
+                    error(player, "Hologramme introuvable.");
                 }
                 return true;
             default:
-                player.sendMessage("§cUsage: /hologram <create|delete|addline|setline|movehere>...");
+                info(player, "Utilisez /hologram help pour la liste des commandes.");
                 return true;
         }
+    }
+
+    private void sendHelp(Player player) {
+        player.sendMessage("§6===== Commandes Hologrammes =====");
+        player.sendMessage("§e/hologram create <nom> <texte> §7- Crée un hologramme");
+        player.sendMessage("§e/hologram delete <nom> §7- Supprime un hologramme");
+        player.sendMessage("§e/hologram addline <nom> <texte> §7- Ajoute une ligne");
+        player.sendMessage("§e/hologram setline <nom> <num> <texte> §7- Modifie une ligne");
+        player.sendMessage("§e/hologram movehere <nom> §7- Déplace l'hologramme ici");
+    }
+
+    @Override
+    public java.util.List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (!(sender instanceof Player) || !sender.hasPermission("heneria.lobby.admin.hologram")) {
+            return java.util.Collections.emptyList();
+        }
+        if (args.length == 1) {
+            return StringUtil.copyPartialMatches(args[0], Arrays.asList("create", "delete", "addline", "setline", "movehere", "help"), new java.util.ArrayList<>());
+        }
+        String sub = args[0].toLowerCase(Locale.ROOT);
+        if (args.length == 2) {
+            switch (sub) {
+                case "delete":
+                case "addline":
+                case "setline":
+                case "movehere":
+                    return StringUtil.copyPartialMatches(args[1], manager.getNames(), new java.util.ArrayList<>());
+                default:
+                    break;
+            }
+        }
+        return java.util.Collections.emptyList();
     }
 }

--- a/src/main/java/net/heneria/henerialobby/hologram/HologramManager.java
+++ b/src/main/java/net/heneria/henerialobby/hologram/HologramManager.java
@@ -118,6 +118,13 @@ public class HologramManager {
         return true;
     }
 
+    /**
+     * Returns a set of all hologram names.
+     */
+    public java.util.Set<String> getNames() {
+        return new java.util.HashSet<>(holograms.keySet());
+    }
+
     public void refreshAll() {
         holograms.values().forEach(Hologram::update);
     }


### PR DESCRIPTION
## Summary
- add colorized success/info/error messages and help output for `/hologram`
- support tab-completion for hologram subcommands and names
- expose hologram names in `HologramManager` and register tab completer in plugin

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2462b99c83298cd091705987ed9c