### PR TITLE
feat: redesign announcer messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.2.1] - Amélioration Visuelle des Annonces Automatiques
+### 🎨 Améliorations
+- Intervalle par défaut des annonces porté à 5 minutes.
+- Refonte du design des messages d'annonce avec un format multi-lignes plus visible.
+
 ## [2.2.0] - Ajout de l'Annonceur Automatique
 ### ✨ Ajouts
 - Ajout d'un système de diffusion de messages automatiques (Auto-Broadcaster).

--- a/src/main/resources/announcer.yml
+++ b/src/main/resources/announcer.yml
@@ -2,17 +2,31 @@
 enabled: true
 
 # Intervalle en secondes entre la diffusion de chaque message.
-interval-seconds: 180 # 3 minutes
+interval-seconds: 300 # 5 minutes
 
 # Diffuser les messages dans un ordre aléatoire (true) ou dans l'ordre de la liste (false).
 random: true
 
 # Ce préfixe sera ajouté avant chaque message de la liste ci-dessous.
-prefix: "&6&l[Info] &e"
+prefix: ""
 
 # Liste des messages à envoyer.
 messages:
-  - "N'oubliez pas de voter pour le serveur avec la commande /vote pour obtenir des récompenses uniques !"
-  - "Visitez notre boutique en ligne pour des grades et cosmétiques exclusifs sur boutique.heneria.com"
-  - "Rejoignez notre communauté sur Discord pour ne rater aucun événement ! /discord"
-  - "Vous avez trouvé un bug ? Signalez-le à un membre du staff pour nous aider à améliorer le serveur."
+  - |2
+
+    &7&m----------------------------------
+    &6&lAnnonce
+
+    &fN'oubliez pas de voter avec &e/vote
+    &fpour des récompenses exclusives !
+
+    &7&m----------------------------------
+  - |2
+
+    &7&m----------------------------------
+    &b&lRéseaux Sociaux
+
+    &fRejoignez notre communauté sur Discord !
+    &e/discord
+
+    &7&m----------------------------------


### PR DESCRIPTION
## Summary
- increase default announcer interval to 5 minutes
- switch announcer prefix to inline message formatting and redesign default messages
- document announcer improvements in changelog

## Testing
- `mvn -q test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2a2bd87c8329881ff72fcaf9a0d0