### PR TITLE
feat: add placeholder support for hologram lines

### DIFF
--- a/src/main/java/net/heneria/henerialobby/hologram/Hologram.java
+++ b/src/main/java/net/heneria/henerialobby/hologram/Hologram.java
@@ -44,9 +44,7 @@ public class Hologram {
     public void spawn() {
         remove();
         for (int i = 0; i < lines.size(); i++) {
-            String raw = lines.get(i);
-            final String parsed = ChatColor.translateAlternateColorCodes('&',
-                    plugin.applyPlaceholders(null, raw));
+            String parsed = parseLine(lines.get(i));
             Location loc = location.clone().subtract(0, 0.25 * i, 0);
             ArmorStand stand = location.getWorld().spawn(loc, ArmorStand.class, as -> {
                 as.setInvisible(true);
@@ -75,10 +73,12 @@ public class Hologram {
     public void update() {
         for (int i = 0; i < stands.size(); i++) {
             ArmorStand stand = stands.get(i);
-            String parsed = plugin.applyPlaceholders(null, lines.get(i));
-            parsed = ChatColor.translateAlternateColorCodes('&', parsed);
-            stand.setCustomName(parsed);
+            stand.setCustomName(parseLine(lines.get(i)));
         }
+    }
+
+    private String parseLine(String text) {
+        return ChatColor.translateAlternateColorCodes('&', plugin.applyPlaceholders(null, text));
     }
 
     public void move(Location newLocation) {

--- a/src/main/resources/holograms.yml
+++ b/src/main/resources/holograms.yml
@@ -1,1 +1,10 @@
 # Saved holograms
+# Example hologram using PlaceholderAPI placeholders
+# bedwars-stats:
+#   world: world
+#   x: 0
+#   y: 80
+#   z: 0
+#   lines:
+#     - "&c&lBedwars"
+#     - "&fJoueurs : &a%bungee_bedwars%"


### PR DESCRIPTION
## Summary
- parse hologram text via PlaceholderAPI before spawning or refreshing stands
- document placeholder usage in `holograms.yml`

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb34c698388329bfdee4d0946a49a6