### PR TITLE
fix: add HeadDatabase repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,10 @@
             <url>https://repo.codemc.org/repository/maven-public/</url>
         </repository>
         <repository>
+            <id>arcaniax-repo</id>
+            <url>https://repo.arcaniax.net/repository/maven-public/</url>
+        </repository>
+        <repository>
             <id>minecraft-repo</id>
             <url>https://libraries.minecraft.net/</url>
         </repository>
@@ -47,7 +51,7 @@
         <dependency>
             <groupId>com.arcaniax</groupId>
             <artifactId>HeadDatabase-API</artifactId>
-            <version>1.3.5</version>
+            <version>1.3.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- add Arcaniax Maven repository
- update HeadDatabase API to 1.3.6

## Testing
- `mvn -q org.apache.maven.plugins:maven-dependency-plugin:3.6.0:resolve` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb399b2ae083298c8eab0bb1b7ae5f