### PR TITLE
[BuildFix] #19.1 - Correction de Dépendance (HeadDatabase Unauthorized 401)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.arcaniax-outsourcing</groupId>
-            <artifactId>HeadDatabase</artifactId>
-            <version>1.3.6</version>
+            <groupId>com.github.Arclight-xyz</groupId>
+            <artifactId>Head-Database</artifactId>
+            <version>5.1.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- replace HeadDatabase dependency with official Arclight-xyz artifact

## Testing
- `mvn clean verify` *(fails: Could not transfer org.apache.maven.plugins:maven-clean-plugin due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3cc810648329affcac37e3935cc8