### PR TITLE
[BuildFix] #19.2 - Correction Définitive de la Dépendance HeadDatabase (Dépôt Officiel)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
             <url>https://repo.codemc.org/repository/maven-public/</url>
         </repository>
         <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
+            <id>arclight-repo</id>
+            <url>https://repo.arclight.xyz/repository/maven-public/</url>
         </repository>
         <repository>
             <id>minecraft-repo</id>


### PR DESCRIPTION
## Summary
- Use official Arclight repository for HeadDatabase instead of JitPack

## Testing
- `mvn -e clean verify` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3dc660288329985aae13f2c1a2d0