### PR TITLE
chore: embed HeadDatabase API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.Arclight-xyz</groupId>
-            <artifactId>Head-Database</artifactId>
-            <version>5.1.2</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.mojang</groupId>
             <artifactId>authlib</artifactId>
             <version>3.11.50</version>

--- a/src/main/java/com/masecla/api/HeadDatabaseAPI.java
+++ b/src/main/java/com/masecla/api/HeadDatabaseAPI.java
@@ -1,0 +1,17 @@
+package com.masecla.api;
+
+import java.util.List;
+import java.util.UUID;
+import org.bukkit.inventory.ItemStack;
+
+public interface HeadDatabaseAPI {
+    ItemStack getItemHead(String id);
+    List<ItemStack> getHeads();
+    List<String> getCategoryNames();
+    List<ItemStack> getHeads(String category);
+    List<ItemStack> getHeads(UUID player);
+    List<ItemStack> getHeadsByTag(String tag);
+    String getHeadID(ItemStack item);
+    boolean isHead(ItemStack item);
+    void search(UUID player, String query);
+}

--- a/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
+++ b/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
@@ -28,6 +28,7 @@ import net.heneria.henerialobby.hologram.HologramManager;
 import net.heneria.henerialobby.npc.NPCManager;
 import net.heneria.henerialobby.npc.NPCCommand;
 import net.heneria.henerialobby.npc.NPCListener;
+import com.masecla.api.HeadDatabaseAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandMap;
@@ -64,6 +65,7 @@ public class HeneriaLobby extends JavaPlugin {
     private NPCManager npcManager;
     private java.util.Set<String> lobbyWorlds;
     private final java.util.Map<String, Command> customCommands = new java.util.HashMap<>();
+    private HeadDatabaseAPI hdbApi = null;
 
     @Override
     public void onEnable() {
@@ -106,6 +108,13 @@ public class HeneriaLobby extends JavaPlugin {
         }
 
         this.getServer().getMessenger().registerOutgoingPluginChannel(this, VELOCITY_CONNECT);
+
+        try {
+            hdbApi = (HeadDatabaseAPI) getServer().getServicesManager().load(HeadDatabaseAPI.class);
+        } catch (NoClassDefFoundError e) {
+            getLogger().warning("HeadDatabase.jar n'est pas installé sur le serveur. La fonctionnalité des têtes personnalisées est désactivée.");
+            hdbApi = null;
+        }
 
         if (hologramManager != null) {
             hologramManager.removeAll();
@@ -187,9 +196,9 @@ public class HeneriaLobby extends JavaPlugin {
           return text;
       }
 
-      public boolean isLobbyWorld(org.bukkit.World world) {
-          return world != null && lobbyWorlds.contains(world.getName());
-      }
+    public boolean isLobbyWorld(org.bukkit.World world) {
+        return world != null && lobbyWorlds.contains(world.getName());
+    }
 
     public void updateDisplays(Player player) {
         if (scoreboardManager != null || tablistManager != null) {
@@ -209,11 +218,12 @@ public class HeneriaLobby extends JavaPlugin {
                 }
                 if (tablistManager != null) {
                     player.setPlayerListHeaderFooter("", "");
-                }
-            }
         }
     }
 
+    public HeadDatabaseAPI getHdbApi() {
+        return hdbApi;
+    }
     public void reloadAll() {
         reloadConfig();
         messages = YamlConfiguration.loadConfiguration(new File(getDataFolder(), "messages.yml"));

--- a/src/main/java/net/heneria/henerialobby/npc/NPCManager.java
+++ b/src/main/java/net/heneria/henerialobby/npc/NPCManager.java
@@ -9,7 +9,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import me.arcaniax.hdb.api.HeadDatabaseAPI;
+import com.masecla.api.HeadDatabaseAPI;
 
 import java.io.File;
 import java.io.IOException;
@@ -177,11 +177,15 @@ public class NPCManager {
     public ItemStack createHead(String input) {
         if (input.startsWith("hdb:")) {
             String id = input.substring(4);
-            try {
-                return new HeadDatabaseAPI().getItemHead(id);
-            } catch (Exception ignored) {
-                return null;
+            HeadDatabaseAPI api = plugin.getHdbApi();
+            if (api != null) {
+                try {
+                    return api.getItemHead(id);
+                } catch (Exception ignored) {
+                    return null;
+                }
             }
+            return null;
         } else {
             var item = new org.bukkit.inventory.ItemStack(org.bukkit.Material.PLAYER_HEAD);
             var meta = (org.bukkit.inventory.meta.SkullMeta) item.getItemMeta();


### PR DESCRIPTION
## Summary
- drop Head-Database dependency and embed its API interface
- load HeadDatabaseAPI from server services and guard usages
- adjust NPC manager to rely on injected HeadDatabaseAPI

## Testing
- `mvn -q -e -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb446f31388329a1f99597e3871673