### PR TITLE
feat: use HeadDatabase heads in server selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.4.0] - Intégration de HeadDatabase dans le GUI
+### ✨ Ajouts
+- Le sélecteur de serveurs peut maintenant utiliser des têtes personnalisées de HeadDatabase pour les icônes des jeux.
+- Ajout du champ `head-id` dans la configuration `server-selector.yml`.
+- Le `material` sert maintenant de solution de repli si une tête ne peut pas être chargée.
+
 ## [2.2.1] - Amélioration Visuelle des Annonces Automatiques
 ### 🎨 Améliorations
 - Intervalle par défaut des annonces porté à 5 minutes.

--- a/README.md
+++ b/README.md
@@ -44,3 +44,18 @@ Ce projet nécessite Java 21 et Maven.
 ```sh
 mvn package
 ```
+
+### Configuration du Sélecteur de Serveurs (`server-selector.yml`)
+
+Pour chaque item, vous pouvez définir un `material` de base et, en option, un `head-id` pour utiliser une tête de HeadDatabase. Si `head-id` est spécifié, il aura la priorité.
+
+**Exemple :**
+
+```yaml
+bedwars:
+  slot: 13
+  material: RED_BED # Utilisé si HeadDatabase est indisponible
+  head-id: '2754'   # ID de la tête à utiliser
+  name: '&6&lBEDWARS'
+  # ...
+```

--- a/src/main/java/net/heneria/henerialobby/selector/ServerSelector.java
+++ b/src/main/java/net/heneria/henerialobby/selector/ServerSelector.java
@@ -128,10 +128,7 @@ public class ServerSelector {
                 if (cs == null) continue;
 
                 if (cs.contains("slots")) {
-                    ItemStack item = new ItemStack(Material.valueOf(cs.getString("material", "STONE")));
-                    ItemMeta meta = item.getItemMeta();
-                    meta.setDisplayName(color(cs.getString("name", " ")));
-                    item.setItemMeta(meta);
+                    ItemStack item = buildItem(cs, player);
                     for (int slot : cs.getIntegerList("slots")) {
                         inv.setItem(slot, item);
                     }
@@ -151,8 +148,23 @@ public class ServerSelector {
     }
 
     private ItemStack buildItem(ConfigurationSection cs, Player player) {
-        String matName = cs.getString("material", "STONE");
-        ItemStack item = new ItemStack(Material.valueOf(matName));
+        ItemStack item = null;
+        String headId = cs.getString("head-id");
+        if (headId != null && plugin.getHdbApi() != null) {
+            try {
+                item = plugin.getHdbApi().getItemHead(headId);
+                if (item != null) {
+                    item = item.clone();
+                }
+            } catch (Exception e) {
+                item = null;
+            }
+        }
+        if (item == null) {
+            String matName = cs.getString("material", "STONE");
+            item = new ItemStack(Material.valueOf(matName));
+        }
+
         ItemMeta meta = item.getItemMeta();
         meta.setDisplayName(color(plugin.applyPlaceholders(player, cs.getString("name", ""))));
         List<String> lore = cs.getStringList("lore");

--- a/src/main/resources/server-selector.yml
+++ b/src/main/resources/server-selector.yml
@@ -8,7 +8,8 @@ items:
 
   bedwars:
     slot: 13
-    material: RED_BED
+    material: RED_BED # Matériau de secours si HeadDatabase est indisponible
+    head-id: '2754' # ID d'une tête décorative de lit rouge
     name: '&6&lBEDWARS &7| &a&lPOPULAIRE'
     enchanted: true
     lore:
@@ -26,7 +27,8 @@ items:
 
   zombie:
     slot: 21
-    material: ZOMBIE_HEAD
+    material: ZOMBIE_HEAD # Matériau de secours
+    head-id: '31202' # ID d'une tête de zombie stylisée
     name: '&2&lZOMBIE &7| &e&lBETA'
     lore:
       - ''


### PR DESCRIPTION
## Summary
- support `head-id` configuration for server selector items and use HeadDatabase API with material fallback
- document head configuration and HeadDatabase integration

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc27b24f448329a8b8fc3a1384bf3e