### PR TITLE
Use HeadDatabase for selector item with fallback

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,8 +7,10 @@ selector-item:
   name: '&aMenu des Jeux &7(Clic Droit)'
   lore:
     - '&7Ouvre le menu pour choisir ton jeu !'
-  # Texture Base64 pour la tête "Terre"
-  texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6InRlc3QifX19"
+  # ID de la tête depuis le plugin HeadDatabase
+  head-id: '33202'
+  # Le matériau ci-dessous ne sera utilisé que si HeadDatabase n'est pas trouvé
+  fallback-material: COMPASS
 
 # Mondes considérés comme des lobbys
 lobby-worlds:


### PR DESCRIPTION
## Summary
- Switch selector item to use HeadDatabase heads with configurable ID
- Fall back to configurable material when HeadDatabase is unavailable
- Update config to use new `head-id` and fallback material fields

## Testing
- `mvn -q package` *(fails: Could not resolve plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2a464c2883299c23c8e3762b20a2