### PR TITLE
Add Mini-Foot admin configuration commands

### DIFF
--- a/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
+++ b/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
@@ -28,6 +28,8 @@ import net.heneria.henerialobby.hologram.HologramManager;
 import net.heneria.henerialobby.npc.NPCManager;
 import net.heneria.henerialobby.npc.NPCCommand;
 import net.heneria.henerialobby.npc.NPCListener;
+import net.heneria.henerialobby.minifoot.MiniFootManager;
+import net.heneria.henerialobby.minifoot.MiniFootAdminCommand;
 import com.masecla.api.HeadDatabaseAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -62,6 +64,7 @@ public class HeneriaLobby extends JavaPlugin {
     private Announcer announcer;
     private HologramManager hologramManager;
     private NPCManager npcManager;
+    private MiniFootManager miniFootManager;
     private java.util.Set<String> lobbyWorlds;
     private final java.util.Map<String, Command> customCommands = new java.util.HashMap<>();
     private HeadDatabaseAPI hdbApi = null;
@@ -98,12 +101,14 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
         saveResourceIfNotExists("holograms.yml");
         saveResourceIfNotExists("npcs.yml");
         saveResourceIfNotExists("npc-actions.yml");
+        saveResourceIfNotExists("minifoot.yml");
         messages = YamlConfiguration.loadConfiguration(new File(getDataFolder(), "messages.yml"));
         scoreboardConfig = YamlConfiguration.loadConfiguration(new File(getDataFolder(), "scoreboard.yml"));
         spawnManager = new SpawnManager(this);
         serverSelector = new ServerSelector(this);
         lobbyWorlds = new java.util.HashSet<>(getConfig().getStringList("lobby-worlds"));
         joinEffectsManager = new JoinEffectsManager(this);
+        miniFootManager = new MiniFootManager(this);
 
         // Debug welcome title configuration loading
         ConfigurationSection welcome = getConfig().getConfigurationSection("interface-and-chat.welcome-title");
@@ -133,6 +138,9 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
         getCommand("setlobby").setExecutor(new SetLobbyCommand(this, spawnManager));
         getCommand("servers").setExecutor(new ServersCommand(serverSelector));
         getCommand("lobbyadmin").setExecutor(new LobbyAdminCommand(this));
+        MiniFootAdminCommand miniFootAdminCommand = new MiniFootAdminCommand(this, miniFootManager);
+        getCommand("minifootadmin").setExecutor(miniFootAdminCommand);
+        getCommand("minifootadmin").setTabCompleter(miniFootAdminCommand);
         hologramManager = new HologramManager(this);
         HologramCommand hologramCommand = new HologramCommand(hologramManager);
         getCommand("hologram").setExecutor(hologramCommand);

--- a/src/main/java/net/heneria/henerialobby/minifoot/MiniFootAdminCommand.java
+++ b/src/main/java/net/heneria/henerialobby/minifoot/MiniFootAdminCommand.java
@@ -1,0 +1,100 @@
+package net.heneria.henerialobby.minifoot;
+
+import net.heneria.henerialobby.HeneriaLobby;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class MiniFootAdminCommand implements CommandExecutor, TabCompleter {
+    private final HeneriaLobby plugin;
+    private final MiniFootManager manager;
+
+    public MiniFootAdminCommand(HeneriaLobby plugin, MiniFootManager manager) {
+        this.plugin = plugin;
+        this.manager = manager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("This command is for players only");
+            return true;
+        }
+        if (!player.hasPermission("heneria.lobby.admin.minifoot")) {
+            player.sendMessage(plugin.getMessage("no-permission"));
+            return true;
+        }
+        if (args.length == 0) {
+            player.sendMessage("Usage: /minifootadmin <setarena|setgoal|setspawn|setballspawn>");
+            return true;
+        }
+        String sub = args[0].toLowerCase();
+        Location loc = player.getLocation();
+        switch (sub) {
+            case "setarena" -> {
+                if (args.length < 2 || (!args[1].equals("1") && !args[1].equals("2"))) {
+                    player.sendMessage("Usage: /minifootadmin setarena <1|2>");
+                    return true;
+                }
+                int index = Integer.parseInt(args[1]);
+                manager.setArenaPos(index, loc);
+                player.sendMessage("Arena corner " + index + " set to " + format(loc));
+            }
+            case "setgoal" -> {
+                if (args.length < 3 || (!args[1].equalsIgnoreCase("blue") && !args[1].equalsIgnoreCase("red"))
+                        || (!args[2].equals("1") && !args[2].equals("2"))) {
+                    player.sendMessage("Usage: /minifootadmin setgoal <blue|red> <1|2>");
+                    return true;
+                }
+                String team = args[1].toLowerCase();
+                int index = Integer.parseInt(args[2]);
+                manager.setTeamGoalPos(team, index, loc);
+                player.sendMessage("Goal " + team + " corner " + index + " set to " + format(loc));
+            }
+            case "setspawn" -> {
+                if (args.length < 2 || (!args[1].equalsIgnoreCase("blue") && !args[1].equalsIgnoreCase("red"))) {
+                    player.sendMessage("Usage: /minifootadmin setspawn <blue|red>");
+                    return true;
+                }
+                String team = args[1].toLowerCase();
+                manager.setTeamSpawn(team, loc);
+                player.sendMessage("Spawn for team " + team + " set to " + format(loc));
+            }
+            case "setballspawn" -> {
+                manager.setBallSpawn(loc);
+                player.sendMessage("Ball spawn set to " + format(loc));
+            }
+            default -> player.sendMessage("Unknown subcommand");
+        }
+        return true;
+    }
+
+    private String format(Location loc) {
+        return String.format("%s %d %d %d", loc.getWorld().getName(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (args.length == 1) {
+            return Arrays.asList("setarena", "setgoal", "setspawn", "setballspawn");
+        }
+        if (args.length == 2) {
+            return switch (args[0].toLowerCase()) {
+                case "setarena" -> Arrays.asList("1", "2");
+                case "setgoal", "setspawn" -> Arrays.asList("blue", "red");
+                default -> Collections.emptyList();
+            };
+        }
+        if (args.length == 3 && args[0].equalsIgnoreCase("setgoal")) {
+            return Arrays.asList("1", "2");
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/net/heneria/henerialobby/minifoot/MiniFootManager.java
+++ b/src/main/java/net/heneria/henerialobby/minifoot/MiniFootManager.java
@@ -1,0 +1,58 @@
+package net.heneria.henerialobby.minifoot;
+
+import net.heneria.henerialobby.HeneriaLobby;
+import org.bukkit.Location;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MiniFootManager {
+    private final HeneriaLobby plugin;
+    private final File configFile;
+    private final FileConfiguration config;
+
+    public MiniFootManager(HeneriaLobby plugin) {
+        this.plugin = plugin;
+        this.configFile = new File(plugin.getDataFolder(), "minifoot.yml");
+        this.config = YamlConfiguration.loadConfiguration(configFile);
+    }
+
+    private void setLocation(String path, Location loc) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("world", loc.getWorld().getName());
+        map.put("x", loc.getBlockX());
+        map.put("y", loc.getBlockY());
+        map.put("z", loc.getBlockZ());
+        config.createSection(path, map);
+        save();
+    }
+
+    public void setArenaPos(int index, Location loc) {
+        config.set("arena.world", loc.getWorld().getName());
+        setLocation("arena.pos" + index, loc);
+    }
+
+    public void setTeamSpawn(String team, Location loc) {
+        setLocation("teams." + team + ".spawn", loc);
+    }
+
+    public void setTeamGoalPos(String team, int index, Location loc) {
+        setLocation("teams." + team + ".goal.pos" + index, loc);
+    }
+
+    public void setBallSpawn(Location loc) {
+        setLocation("ball-spawn", loc);
+    }
+
+    private void save() {
+        try {
+            config.save(configFile);
+        } catch (IOException e) {
+            plugin.getLogger().severe("Could not save minifoot.yml: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/minifoot.yml
+++ b/src/main/resources/minifoot.yml
@@ -1,0 +1,19 @@
+enabled: true
+match-duration-seconds: 300
+score-to-win: 3
+arena:
+  world: "lobby"
+  pos1: {x: 100, y: 64, z: 200}
+  pos2: {x: 150, y: 70, z: 250}
+ball-spawn: {world: "lobby", x: 125, y: 65, z: 225}
+teams:
+  blue:
+    spawn: {world: "lobby", x: 105, y: 65, z: 225}
+    goal:
+      pos1: {world: "lobby", x: 98, y: 64, z: 220}
+      pos2: {world: "lobby", x: 100, y: 68, z: 230}
+  red:
+    spawn: {world: "lobby", x: 145, y: 65, z: 225}
+    goal:
+      pos1: {world: "lobby", x: 150, y: 64, z: 220}
+      pos2: {world: "lobby", x: 152, y: 68, z: 230}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -29,6 +29,10 @@ commands:
     description: "Gestion des PNJ"
     usage: "/npc <create|delete|select|move|skin|equip|unequip|link|help>"
     permission: heneria.lobby.admin.npc
+  minifootadmin:
+    description: "Configuration du mini-jeu Mini-Foot"
+    usage: "/minifootadmin <setarena|setgoal|setspawn|setballspawn>"
+    permission: heneria.lobby.admin.minifoot
 permissions:
   heneria.lobby.admin:
     description: "Permet de configurer le spawn du lobby"
@@ -47,4 +51,7 @@ permissions:
     default: op
   heneria.lobby.admin.npc:
     description: "Permet de gérer les PNJ"
+    default: op
+  heneria.lobby.admin.minifoot:
+    description: "Permet de configurer l'arène du Mini-Foot"
     default: op


### PR DESCRIPTION
## Summary
- add MiniFootManager and MiniFootAdminCommand to configure arenas, goals, spawns, and ball spawn
- register `minifootadmin` command and default configuration file

## Testing
- `mvn -q -e -DskipTests package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4f9d3d3c832989e4ee5f12dc6c0d