### PR TITLE
Fix arena coordinate loading with debug checks

### DIFF
--- a/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
+++ b/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
@@ -170,7 +170,7 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
         }
         Bukkit.getPluginManager().registerEvents(new JoinEffectsListener(joinEffectsManager), this);
         Bukkit.getPluginManager().registerEvents(new InterfaceChatListener(this), this);
-        Bukkit.getPluginManager().registerEvents(new MiniFootListener(this), this);
+        Bukkit.getPluginManager().registerEvents(new MiniFootListener(this, miniFootManager), this);
 
         if (getConfig().getBoolean("scoreboard.enabled", true)) {
             scoreboardManager = new ScoreboardManager(this, scoreboardConfig);
@@ -311,7 +311,7 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
         }
         Bukkit.getPluginManager().registerEvents(new JoinEffectsListener(joinEffectsManager), this);
         Bukkit.getPluginManager().registerEvents(new InterfaceChatListener(this), this);
-        Bukkit.getPluginManager().registerEvents(new MiniFootListener(this), this);
+        Bukkit.getPluginManager().registerEvents(new MiniFootListener(this, miniFootManager), this);
         Bukkit.getPluginManager().registerEvents(new NPCListener(npcManager), this);
 
         hologramManager = new HologramManager(this);

--- a/src/main/java/net/heneria/henerialobby/minifoot/MiniFootListener.java
+++ b/src/main/java/net/heneria/henerialobby/minifoot/MiniFootListener.java
@@ -1,44 +1,20 @@
 package net.heneria.henerialobby.minifoot;
 
 import net.heneria.henerialobby.HeneriaLobby;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
-
-import java.io.File;
 
 public class MiniFootListener implements Listener {
 
     private final HeneriaLobby plugin;
-    private final FileConfiguration miniFootConfig;
+    private final MiniFootManager miniFootManager;
 
-    public MiniFootListener(HeneriaLobby plugin) {
+    public MiniFootListener(HeneriaLobby plugin, MiniFootManager miniFootManager) {
         this.plugin = plugin;
-        this.miniFootConfig = YamlConfiguration.loadConfiguration(new File(plugin.getDataFolder(), "minifoot.yml"));
-    }
-
-    private Location getLocation(String path) {
-        if (!miniFootConfig.isConfigurationSection(path)) {
-            return null;
-        }
-        String worldName = miniFootConfig.getString(path + ".world");
-        if (worldName == null) {
-            return null;
-        }
-        World world = Bukkit.getWorld(worldName);
-        if (world == null) {
-            return null;
-        }
-        int x = miniFootConfig.getInt(path + ".x");
-        int y = miniFootConfig.getInt(path + ".y");
-        int z = miniFootConfig.getInt(path + ".z");
-        return new Location(world, x, y, z);
+        this.miniFootManager = miniFootManager;
     }
 
     @EventHandler
@@ -55,8 +31,8 @@ public class MiniFootListener implements Listener {
             return;
         }
 
-        Location arenaPos1 = getLocation("arena.pos1");
-        Location arenaPos2 = getLocation("arena.pos2");
+        Location arenaPos1 = miniFootManager.loadLocationFromConfig(plugin, "arena.pos1");
+        Location arenaPos2 = miniFootManager.loadLocationFromConfig(plugin, "arena.pos2");
 
         if (arenaPos1 == null || arenaPos2 == null) {
             return;


### PR DESCRIPTION
## Summary
- add robust `loadLocationFromConfig` helper for minifoot arena coordinates with detailed debug logging
- use new loader in arena movement listener
- wire listener through MiniFootManager during enable and reload

## Testing
- `mvn -q -e test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6020ff4c83298aa787a66d35e7e9