### PR TITLE
[BugFix] #17.9 - Finalisation du Cycle de Jeu du Mini-Foot (Spawn, Stuff, Scoreboard, Sortie)

### DIFF
--- a/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
+++ b/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
@@ -372,5 +372,9 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
     public ServerSelector getServerSelector() {
         return serverSelector;
     }
+
+    public VisibilityManager getVisibilityManager() {
+        return visibilityManager;
+    }
 }
 

--- a/src/main/java/net/heneria/henerialobby/minifoot/MiniFootListener.java
+++ b/src/main/java/net/heneria/henerialobby/minifoot/MiniFootListener.java
@@ -31,13 +31,6 @@ public class MiniFootListener implements Listener {
         // --- TRACE 1 ---
         plugin.getLogger().info("[TRACE 1] Événement de mouvement détecté pour " + player.getName());
 
-        // Vérification si le joueur est déjà dans une partie
-        if (miniFootManager.isInGame(player)) {
-            // --- TRACE 2 ---
-            plugin.getLogger().info("[TRACE 2] Le joueur est DÉJÀ en partie. La logique s'arrête ici.");
-            return;
-        }
-
         // Chargement des positions de l'arène
         Location pos1 = miniFootManager.getArenaPos1();
         Location pos2 = miniFootManager.getArenaPos2();
@@ -73,6 +66,18 @@ public class MiniFootListener implements Listener {
 
         // --- TRACE 6 ---
         plugin.getLogger().info("[TRACE 6] Vérification de la position... Le joueur est à l'intérieur ? -> " + isInside);
+
+        if (miniFootManager.isInGame(player)) {
+            if (!isInside) {
+                // --- TRACE 8 ---
+                plugin.getLogger().info("[TRACE 8] Le joueur quitte la zone. Retrait de la partie...");
+                miniFootManager.removePlayerFromGame(player);
+            } else {
+                // --- TRACE 2 ---
+                plugin.getLogger().info("[TRACE 2] Le joueur est DÉJÀ en partie et reste dans la zone.");
+            }
+            return;
+        }
 
         if (isInside) {
             // --- TRACE 7 ---


### PR DESCRIPTION
## Summary
- add debug logs, spawn teleport, and complete armor set when joining a Mini-Foot team
- implement player removal from Mini-Foot with inventory reset and lobby item restoration
- handle arena exit detection and expose visibility manager

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*
- `mvn -q -o test` *(fails: Cannot access central in offline mode and the artifact org.apache.maven.plugins:maven-resources-plugin:jar:3.3.1 has not been downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5367d03c8329b9dbe8223ec274a4