### PR TITLE
feat(minifoot): limit arena players and protect armor

### DIFF
--- a/src/main/java/net/heneria/henerialobby/minifoot/MiniFootListener.java
+++ b/src/main/java/net/heneria/henerialobby/minifoot/MiniFootListener.java
@@ -5,6 +5,8 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerMoveEvent;
 
 public class MiniFootListener implements Listener {
@@ -83,6 +85,19 @@ public class MiniFootListener implements Listener {
             // --- TRACE 7 ---
             plugin.getLogger().info("[TRACE 7] Le joueur EST DANS LA ZONE. Appel de la méthode pour rejoindre une équipe...");
             miniFootManager.addPlayerToTeam(player);
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) {
+            return;
+        }
+        if (!miniFootManager.isInGame(player)) {
+            return;
+        }
+        if (event.getSlotType() == InventoryType.SlotType.ARMOR) {
+            event.setCancelled(true);
         }
     }
 }

--- a/src/main/java/net/heneria/henerialobby/minifoot/MiniFootManager.java
+++ b/src/main/java/net/heneria/henerialobby/minifoot/MiniFootManager.java
@@ -90,6 +90,14 @@ public class MiniFootManager {
     }
 
     public void addPlayerToTeam(Player player) {
+        int maxPlayers = config.getInt("max-players", 8);
+        if (playersInGame.size() >= maxPlayers) {
+            String msg = plugin.getMessage("minifoot.arena-full")
+                    .replace("%current_players%", String.valueOf(playersInGame.size()))
+                    .replace("%max_players%", String.valueOf(maxPlayers));
+            player.sendMessage(plugin.applyPlaceholders(player, msg));
+            return;
+        }
         teamPlayers.computeIfAbsent("blue", k -> new HashSet<>());
         teamPlayers.computeIfAbsent("red", k -> new HashSet<>());
 

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -11,3 +11,9 @@ visibility-none: "&7Visibilité : Personne."
 minifoot-join-blue: "&aVous avez rejoint l'équipe &9bleue&a !"
 minifoot-join-red: "&aVous avez rejoint l'équipe &crouge&a !"
 
+minifoot:
+  arena-full: "&cL'arène de Mini-Foot est pleine ! (%current_players%/%max_players%)"
+  countdown-title: "&a%seconds_left%..."
+  countdown-subtitle: "&ePréparez-vous !"
+  countdown-go: "&6&lJOUEZ !"
+

--- a/src/main/resources/minifoot.yml
+++ b/src/main/resources/minifoot.yml
@@ -1,6 +1,7 @@
 # Paramètres du jeu
 enabled: true
 score-to-win: 3 # La partie se termine quand une équipe atteint ce score.
+max-players: 8 # Nombre maximal de joueurs autorisés dans l'arène
 
 arena:
   world: "lobby"


### PR DESCRIPTION
## Summary
- add configurable max player limit with arena-full message
- block armor slot interaction during mini-foot games
- include new default config and messages for upcoming countdown

## Testing
- `mvn -q -e package` *(fails: Network is unreachable)*
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5a24cc4c83298b4cdbc1a169c697