### PR TITLE
feat: finalize mini-foot gameplay

### DIFF
--- a/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
+++ b/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
@@ -110,6 +110,7 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
         lobbyWorlds = new java.util.HashSet<>(getConfig().getStringList("lobby-worlds"));
         joinEffectsManager = new JoinEffectsManager(this);
         miniFootManager = new MiniFootManager(this);
+        miniFootManager.spawnBall();
 
         // Debug welcome title configuration loading
         ConfigurationSection welcome = getConfig().getConfigurationSection("interface-and-chat.welcome-title");

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -8,11 +8,11 @@ visibility-all: "&aVisibilité : Tous les joueurs."
 visibility-vips: "&eVisibilité : VIPs et Staff uniquement."
 visibility-none: "&7Visibilité : Personne."
 
-minifoot-join-blue: "&aVous avez rejoint l'équipe &9bleue&a !"
-minifoot-join-red: "&aVous avez rejoint l'équipe &crouge&a !"
-
 minifoot:
-  arena-full: "&cL'arène de Mini-Foot est pleine ! (%current_players%/%max_players%)"
+  join-team: "&8[&a⚽&8] &7Vous avez rejoint l'équipe %team_color%%team_name%&7 !"
+  goal-scored: "&6&lBUUUUT ! &fL'équipe %team_color%%team_name% &fa marqué ! Le score est de &9%blue_score% &f- &c%red_score%&f."
+  game-won: "&6&lVICTOIRE ! &fL'équipe %team_color%%team_name% &fa remporté la partie ! L'arène sera réinitialisée dans 15 secondes."
+  arena-full: "&c&lCOMPLET ! &7L'arène de Mini-Foot est pleine pour le moment."
   countdown-title: "&a%seconds_left%..."
   countdown-subtitle: "&ePréparez-vous !"
   countdown-go: "&6&lJOUEZ !"


### PR DESCRIPTION
## Summary
- fix mini-foot scoreboard reset by applying it after teleport
- spawn and orient players toward the ball
- add configurable messages and ball spawn routine

## Testing
- `mvn -q -e -ntp test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5b8e796c8329a5b4037bb6fc21b2