### PR TITLE
[BugFix Final] #18.3 - Correction du Scoreboard Persistant et Physique du Ballon

### DIFF
--- a/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
+++ b/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
@@ -31,6 +31,7 @@ import net.heneria.henerialobby.npc.NPCListener;
 import net.heneria.henerialobby.minifoot.MiniFootManager;
 import net.heneria.henerialobby.minifoot.MiniFootAdminCommand;
 import net.heneria.henerialobby.minifoot.MiniFootListener;
+import net.heneria.henerialobby.minifoot.MiniFootBallListener;
 import com.masecla.api.HeadDatabaseAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -172,6 +173,7 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
         Bukkit.getPluginManager().registerEvents(new JoinEffectsListener(joinEffectsManager), this);
         Bukkit.getPluginManager().registerEvents(new InterfaceChatListener(this), this);
         Bukkit.getPluginManager().registerEvents(new MiniFootListener(this, miniFootManager), this);
+        Bukkit.getPluginManager().registerEvents(new MiniFootBallListener(miniFootManager), this);
 
         if (getConfig().getBoolean("scoreboard.enabled", true)) {
             scoreboardManager = new ScoreboardManager(this, scoreboardConfig);
@@ -313,6 +315,7 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
         Bukkit.getPluginManager().registerEvents(new JoinEffectsListener(joinEffectsManager), this);
         Bukkit.getPluginManager().registerEvents(new InterfaceChatListener(this), this);
         Bukkit.getPluginManager().registerEvents(new MiniFootListener(this, miniFootManager), this);
+        Bukkit.getPluginManager().registerEvents(new MiniFootBallListener(miniFootManager), this);
         Bukkit.getPluginManager().registerEvents(new NPCListener(npcManager), this);
 
         hologramManager = new HologramManager(this);
@@ -376,6 +379,10 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
 
     public VisibilityManager getVisibilityManager() {
         return visibilityManager;
+    }
+
+    public MiniFootManager getMiniFootManager() {
+        return miniFootManager;
     }
 }
 

--- a/src/main/java/net/heneria/henerialobby/minifoot/MiniFootBallListener.java
+++ b/src/main/java/net/heneria/henerialobby/minifoot/MiniFootBallListener.java
@@ -1,0 +1,31 @@
+package net.heneria.henerialobby.minifoot;
+
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Slime;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.util.Vector;
+
+public class MiniFootBallListener implements Listener {
+
+    private final MiniFootManager miniFootManager;
+
+    public MiniFootBallListener(MiniFootManager miniFootManager) {
+        this.miniFootManager = miniFootManager;
+    }
+
+    @EventHandler
+    public void onBallHit(EntityDamageByEntityEvent event) {
+        if (!(event.getEntity() instanceof Slime slime) || !(event.getDamager() instanceof Player player)) {
+            return;
+        }
+        if (!miniFootManager.isBall(slime)) {
+            return;
+        }
+        event.setCancelled(true);
+        Vector direction = slime.getLocation().toVector().subtract(player.getLocation().toVector()).normalize();
+        direction.setY(0.3);
+        slime.setVelocity(direction.multiply(miniFootManager.getBallPushMultiplier()));
+    }
+}

--- a/src/main/java/net/heneria/henerialobby/minifoot/MiniFootManager.java
+++ b/src/main/java/net/heneria/henerialobby/minifoot/MiniFootManager.java
@@ -215,6 +215,14 @@ public class MiniFootManager {
                 + loc.getBlockX() + ", " + loc.getBlockY() + ", " + loc.getBlockZ() + ".");
     }
 
+    public boolean isBall(Slime slime) {
+        return ball != null && ball.equals(slime);
+    }
+
+    public double getBallPushMultiplier() {
+        return config.getDouble("ball-push-multiplier", 1.2);
+    }
+
     private void applyMiniFootScoreboard(Player player) {
         var manager = Bukkit.getScoreboardManager();
         plugin.getLogger().info("[DEBUG] Tentative d'application du scoreboard de mini-foot pour " + player.getName());

--- a/src/main/java/net/heneria/henerialobby/scoreboard/ScoreboardManager.java
+++ b/src/main/java/net/heneria/henerialobby/scoreboard/ScoreboardManager.java
@@ -25,6 +25,10 @@ public class ScoreboardManager {
 
     public void updateAll() {
         for (Player player : Bukkit.getOnlinePlayers()) {
+            var miniFoot = plugin.getMiniFootManager();
+            if (miniFoot != null && miniFoot.isInGame(player)) {
+                continue;
+            }
             if (plugin.isLobbyWorld(player.getWorld())) {
                 update(player);
             } else {
@@ -37,6 +41,10 @@ public class ScoreboardManager {
     }
 
     public void update(Player player) {
+        var miniFoot = plugin.getMiniFootManager();
+        if (miniFoot != null && miniFoot.isInGame(player)) {
+            return;
+        }
         var manager = Bukkit.getScoreboardManager();
         if (manager == null) {
             return;

--- a/src/main/resources/minifoot.yml
+++ b/src/main/resources/minifoot.yml
@@ -3,6 +3,9 @@ enabled: true
 score-to-win: 3 # La partie se termine quand une équipe atteint ce score.
 max-players: 8 # Nombre maximal de joueurs autorisés dans l'arène
 
+# Multiplicateur pour la puissance de frappe du ballon
+ball-push-multiplier: 1.2
+
 arena:
   world: "lobby"
   pos1: {x: 100, y: 64, z: 200}


### PR DESCRIPTION
## Summary
- Keep lobby scoreboard from overriding mini-foot score by skipping players in match
- Introduce configurable ball knockback and event listener to handle hits

## Testing
- `mvn -q test` *(fails: Could not transfer artifact: Network is unreachable)*
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd657b1244832984571bc597b898ba