### PR TITLE
feat: add custom physics for mini-foot ball

### DIFF
--- a/src/main/resources/minifoot.yml
+++ b/src/main/resources/minifoot.yml
@@ -6,6 +6,11 @@ max-players: 8 # Nombre maximal de joueurs autorisés dans l'arène
 # Multiplicateur pour la puissance de frappe du ballon
 ball-push-multiplier: 1.2
 
+# Facteur de glissade. Plus il est proche de 1.0, plus le ballon glisse longtemps.
+ball-slide-factor: 0.98
+# Facteur de rebond. Négatif pour inverser la direction. Entre -0.7 et -0.9 pour un rebond réaliste.
+ball-bounce-factor: -0.8
+
 arena:
   world: "lobby"
   pos1: {x: 100, y: 64, z: 200}


### PR DESCRIPTION
## Summary
- prevent slime-based football from jumping by disabling AI
- add per-tick physics task to apply sliding friction and wall bounces
- expose slide and bounce factors in `minifoot.yml`

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7a52fb1c8329ac9276254379cda8