### PR TITLE
[BugFix] Identify Mini-Foot ball via metadata

### DIFF
--- a/src/main/java/net/heneria/henerialobby/minifoot/MiniFootBallListener.java
+++ b/src/main/java/net/heneria/henerialobby/minifoot/MiniFootBallListener.java
@@ -1,6 +1,12 @@
 package net.heneria.henerialobby.minifoot;
 
+import org.bukkit.Sound;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Slime;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.util.Vector;
 
 public class MiniFootBallListener implements Listener {
 
@@ -10,6 +16,24 @@ public class MiniFootBallListener implements Listener {
         this.miniFootManager = miniFootManager;
     }
 
-    // Ancienne mécanique de tir par clic gauche supprimée.
-    // La poussée du ballon est désormais gérée par contact dans MiniFootListener#onPlayerMove.
+    @EventHandler
+    public void onEntityDamage(EntityDamageByEntityEvent event) {
+        if (!(event.getDamager() instanceof Player player)) {
+            return;
+        }
+
+        if (!miniFootManager.isTheFootball(event.getEntity())) {
+            return;
+        }
+
+        event.setCancelled(true);
+
+        Slime ball = (Slime) event.getEntity();
+        Vector direction = player.getLocation().getDirection().normalize();
+        direction.setY(0.35);
+        double pushPower = miniFootManager.getBallPushMultiplier();
+        ball.setVelocity(direction.multiply(pushPower));
+
+        player.playSound(player.getLocation(), Sound.ENTITY_SLIME_SQUISH_SMALL, 0.5f, 1.0f);
+    }
 }

--- a/src/main/java/net/heneria/henerialobby/minifoot/MiniFootListener.java
+++ b/src/main/java/net/heneria/henerialobby/minifoot/MiniFootListener.java
@@ -92,7 +92,7 @@ public class MiniFootListener implements Listener {
             plugin.getLogger().info("[PUSH-DEBUG-1] Le joueur '" + player.getName() + "' est en jeu, vérification de la collision.");
 
             Slime ball = miniFootManager.getBall();
-            if (ball == null) {
+            if (ball == null || !miniFootManager.isTheFootball(ball)) {
                 return;
             }
 


### PR DESCRIPTION
## Summary
- tag spawned football with persistent metadata
- replace object comparison with metadata-based `isTheFootball`
- clear arena of old slimes before spawning new ball
- use metadata checks in move and damage events for pushes and shots

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb6812f448329b42ff6f6bfbcb8c9