### PR TITLE
feat: add Mini-Foot admin command suite

### DIFF
--- a/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
+++ b/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
@@ -29,6 +29,8 @@ import net.heneria.henerialobby.npc.NPCManager;
 import net.heneria.henerialobby.npc.NPCCommand;
 import net.heneria.henerialobby.npc.NPCListener;
 import net.heneria.henerialobby.minifoot.MiniFootManager;
+import net.heneria.henerialobby.minifoot.MiniFootAdminCommand;
+import net.heneria.henerialobby.minifoot.MiniFootSelectionListener;
 import com.masecla.api.HeadDatabaseAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -109,6 +111,8 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
         joinEffectsManager = new JoinEffectsManager(this);
         miniFootManager = new MiniFootManager(this);
         miniFootManager.loadAndStart();
+        MiniFootSelectionListener miniFootSelectionListener = new MiniFootSelectionListener();
+        Bukkit.getPluginManager().registerEvents(miniFootSelectionListener, this);
 
         // Debug welcome title configuration loading
         ConfigurationSection welcome = getConfig().getConfigurationSection("interface-and-chat.welcome-title");
@@ -138,6 +142,7 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
         getCommand("setlobby").setExecutor(new SetLobbyCommand(this, spawnManager));
         getCommand("servers").setExecutor(new ServersCommand(serverSelector));
         getCommand("lobbyadmin").setExecutor(new LobbyAdminCommand(this));
+        getCommand("minifootadmin").setExecutor(new MiniFootAdminCommand(this, miniFootManager, miniFootSelectionListener));
         hologramManager = new HologramManager(this);
         HologramCommand hologramCommand = new HologramCommand(hologramManager);
         getCommand("hologram").setExecutor(hologramCommand);
@@ -258,6 +263,7 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
         joinEffectsManager = new JoinEffectsManager(this);
         miniFootManager = new MiniFootManager(this);
         miniFootManager.loadAndStart();
+        MiniFootSelectionListener miniFootSelectionListener = new MiniFootSelectionListener();
 
         getCommand("lobby").setExecutor(new LobbyCommand(this, spawnManager));
         getCommand("setlobby").setExecutor(new SetLobbyCommand(this, spawnManager));
@@ -266,6 +272,7 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
         NPCCommand npcCommand = new NPCCommand(npcManager);
         getCommand("npc").setExecutor(npcCommand);
         getCommand("npc").setTabCompleter(npcCommand);
+        getCommand("minifootadmin").setExecutor(new MiniFootAdminCommand(this, miniFootManager, miniFootSelectionListener));
 
         org.bukkit.Bukkit.getScheduler().cancelTasks(this);
         HandlerList.unregisterAll(this);
@@ -309,6 +316,7 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
         Bukkit.getPluginManager().registerEvents(new JoinEffectsListener(joinEffectsManager), this);
         Bukkit.getPluginManager().registerEvents(new InterfaceChatListener(this), this);
         Bukkit.getPluginManager().registerEvents(new NPCListener(npcManager), this);
+        Bukkit.getPluginManager().registerEvents(miniFootSelectionListener, this);
 
         hologramManager = new HologramManager(this);
         HologramCommand hologramCommand = new HologramCommand(hologramManager);

--- a/src/main/java/net/heneria/henerialobby/minifoot/MiniFootAdminCommand.java
+++ b/src/main/java/net/heneria/henerialobby/minifoot/MiniFootAdminCommand.java
@@ -1,0 +1,107 @@
+package net.heneria.henerialobby.minifoot;
+
+import net.heneria.henerialobby.HeneriaLobby;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class MiniFootAdminCommand implements CommandExecutor {
+
+    private final HeneriaLobby plugin;
+    private final MiniFootManager manager;
+    private final MiniFootSelectionListener selector;
+
+    public MiniFootAdminCommand(HeneriaLobby plugin, MiniFootManager manager, MiniFootSelectionListener selector) {
+        this.plugin = plugin;
+        this.manager = manager;
+        this.selector = selector;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(plugin.getMessage("player-only"));
+            return true;
+        }
+
+        if (!player.hasPermission("heneria.lobby.admin.minifoot")) {
+            player.sendMessage(plugin.getMessage("no-permission"));
+            return true;
+        }
+
+        if (args.length == 0 || args[0].equalsIgnoreCase("help")) {
+            sendHelp(player, label);
+            return true;
+        }
+
+        switch (args[0].toLowerCase()) {
+            case "setarena" -> {
+                Location p1 = selector.getPos1(player.getUniqueId());
+                Location p2 = selector.getPos2(player.getUniqueId());
+                if (p1 == null || p2 == null) {
+                    player.sendMessage(ChatColor.RED + "Vous devez sélectionner deux positions avec la hache.");
+                    return true;
+                }
+                manager.saveArena(p1, p2);
+                player.sendMessage(ChatColor.GREEN + "[MiniFoot] La zone de l'arène a été définie avec succès !");
+            }
+            case "setgoal" -> {
+                if (args.length < 2) {
+                    player.sendMessage(ChatColor.RED + "Usage: /" + label + " setgoal <blue|red>");
+                    return true;
+                }
+                Location p1 = selector.getPos1(player.getUniqueId());
+                Location p2 = selector.getPos2(player.getUniqueId());
+                if (p1 == null || p2 == null) {
+                    player.sendMessage(ChatColor.RED + "Vous devez sélectionner deux positions avec la hache.");
+                    return true;
+                }
+                String team = args[1].equalsIgnoreCase("blue") ? "blue" : args[1].equalsIgnoreCase("red") ? "red" : null;
+                if (team == null) {
+                    player.sendMessage(ChatColor.RED + "Usage: /" + label + " setgoal <blue|red>");
+                    return true;
+                }
+                manager.saveGoal(team, p1, p2);
+                if (team.equals("blue")) {
+                    player.sendMessage(ChatColor.GREEN + "[MiniFoot] La zone de but pour l'équipe §9BLEUE §aa été définie.");
+                } else {
+                    player.sendMessage(ChatColor.GREEN + "[MiniFoot] La zone de but pour l'équipe §cROUGE §aa été définie.");
+                }
+            }
+            case "setspawn" -> {
+                if (args.length < 2) {
+                    player.sendMessage(ChatColor.RED + "Usage: /" + label + " setspawn <blue|red>");
+                    return true;
+                }
+                String team = args[1].equalsIgnoreCase("blue") ? "blue" : args[1].equalsIgnoreCase("red") ? "red" : null;
+                if (team == null) {
+                    player.sendMessage(ChatColor.RED + "Usage: /" + label + " setspawn <blue|red>");
+                    return true;
+                }
+                manager.saveSpawn(team, player.getLocation());
+                if (team.equals("blue")) {
+                    player.sendMessage(ChatColor.GREEN + "[MiniFoot] Le spawn de l'équipe §9BLEUE §aa été défini.");
+                } else {
+                    player.sendMessage(ChatColor.GREEN + "[MiniFoot] Le spawn de l'équipe §cROUGE §aa été défini.");
+                }
+            }
+            case "setballspawn" -> {
+                manager.saveBallSpawn(player.getLocation());
+                player.sendMessage(ChatColor.GREEN + "[MiniFoot] Le spawn de la balle a été défini.");
+            }
+            default -> sendHelp(player, label);
+        }
+        return true;
+    }
+
+    private void sendHelp(Player player, String label) {
+        player.sendMessage(ChatColor.YELLOW + "--- MiniFoot Admin ---");
+        player.sendMessage(ChatColor.GOLD + "/" + label + " setarena" + ChatColor.WHITE + " - Définir l'arène" );
+        player.sendMessage(ChatColor.GOLD + "/" + label + " setgoal <blue|red>" + ChatColor.WHITE + " - Définir le but" );
+        player.sendMessage(ChatColor.GOLD + "/" + label + " setspawn <blue|red>" + ChatColor.WHITE + " - Définir le spawn" );
+        player.sendMessage(ChatColor.GOLD + "/" + label + " setballspawn" + ChatColor.WHITE + " - Définir le spawn de la balle" );
+    }
+}

--- a/src/main/java/net/heneria/henerialobby/minifoot/MiniFootManager.java
+++ b/src/main/java/net/heneria/henerialobby/minifoot/MiniFootManager.java
@@ -25,6 +25,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -277,5 +278,70 @@ public class MiniFootManager implements Listener {
 
     public boolean isInGame(UUID uuid) {
         return blueTeam.contains(uuid) || redTeam.contains(uuid);
+    }
+
+    public void saveArena(Location pos1, Location pos2) {
+        File file = new File(plugin.getDataFolder(), "minifoot.yml");
+        FileConfiguration config = YamlConfiguration.loadConfiguration(file);
+        config.set("arena.world", pos1.getWorld().getName());
+        config.set("arena.pos1.x", pos1.getX());
+        config.set("arena.pos1.y", pos1.getY());
+        config.set("arena.pos1.z", pos1.getZ());
+        config.set("arena.pos2.x", pos2.getX());
+        config.set("arena.pos2.y", pos2.getY());
+        config.set("arena.pos2.z", pos2.getZ());
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        loadAndStart();
+    }
+
+    public void saveGoal(String team, Location pos1, Location pos2) {
+        File file = new File(plugin.getDataFolder(), "minifoot.yml");
+        FileConfiguration config = YamlConfiguration.loadConfiguration(file);
+        String base = "teams." + team + ".goal";
+        config.set(base + ".pos1.x", pos1.getX());
+        config.set(base + ".pos1.y", pos1.getY());
+        config.set(base + ".pos1.z", pos1.getZ());
+        config.set(base + ".pos2.x", pos2.getX());
+        config.set(base + ".pos2.y", pos2.getY());
+        config.set(base + ".pos2.z", pos2.getZ());
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        loadAndStart();
+    }
+
+    public void saveSpawn(String team, Location loc) {
+        File file = new File(plugin.getDataFolder(), "minifoot.yml");
+        FileConfiguration config = YamlConfiguration.loadConfiguration(file);
+        String base = "teams." + team + ".spawn";
+        config.set(base + ".x", loc.getX());
+        config.set(base + ".y", loc.getY());
+        config.set(base + ".z", loc.getZ());
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        loadAndStart();
+    }
+
+    public void saveBallSpawn(Location loc) {
+        File file = new File(plugin.getDataFolder(), "minifoot.yml");
+        FileConfiguration config = YamlConfiguration.loadConfiguration(file);
+        config.set("ball-spawn.x", loc.getX());
+        config.set("ball-spawn.y", loc.getY());
+        config.set("ball-spawn.z", loc.getZ());
+        try {
+            config.save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        loadAndStart();
     }
 }

--- a/src/main/java/net/heneria/henerialobby/minifoot/MiniFootSelectionListener.java
+++ b/src/main/java/net/heneria/henerialobby/minifoot/MiniFootSelectionListener.java
@@ -1,0 +1,48 @@
+package net.heneria.henerialobby.minifoot;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.block.Action;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class MiniFootSelectionListener implements Listener {
+
+    private final Map<UUID, Location> pos1 = new HashMap<>();
+    private final Map<UUID, Location> pos2 = new HashMap<>();
+
+    public Location getPos1(UUID uuid) {
+        return pos1.get(uuid);
+    }
+
+    public Location getPos2(UUID uuid) {
+        return pos2.get(uuid);
+    }
+
+    @EventHandler
+    public void onInteract(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        if (!player.hasPermission("heneria.lobby.admin.minifoot")) return;
+        if (player.getInventory().getItemInMainHand().getType() != Material.WOODEN_AXE) return;
+        Action action = event.getAction();
+        Block block = event.getClickedBlock();
+        if (block == null) return;
+        if (action == Action.LEFT_CLICK_BLOCK) {
+            pos1.put(player.getUniqueId(), block.getLocation());
+            player.sendMessage(ChatColor.GREEN + "Position 1 définie.");
+            event.setCancelled(true);
+        } else if (action == Action.RIGHT_CLICK_BLOCK) {
+            pos2.put(player.getUniqueId(), block.getLocation());
+            player.sendMessage(ChatColor.GREEN + "Position 2 définie.");
+            event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -29,6 +29,10 @@ commands:
     description: "Gestion des PNJ"
     usage: "/npc <create|delete|select|move|skin|equip|unequip|link|help>"
     permission: heneria.lobby.admin.npc
+  minifootadmin:
+    description: "Commandes d'administration du Mini-Foot"
+    usage: "/minifootadmin <subcommand>"
+    permission: heneria.lobby.admin.minifoot
 permissions:
   heneria.lobby.admin:
     description: "Permet de configurer le spawn du lobby"
@@ -47,4 +51,7 @@ permissions:
     default: op
   heneria.lobby.admin.npc:
     description: "Permet de gérer les PNJ"
+    default: op
+  heneria.lobby.admin.minifoot:
+    description: "Permet de gérer le Mini-Foot"
     default: op


### PR DESCRIPTION
## Summary
- add `/minifootadmin` with subcommands for arena, goals, spawns and ball spawn
- provide wooden axe selection tool for defining regions
- persist Mini-Foot locations to `minifoot.yml` and register command and listener

## Testing
- `mvn -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcdd4d0d8832993cae0e25857aee6