### PR TITLE
[MiniFoot] Arena auto join and leave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased] - Développement en cours
 
 - Implémentation du ballon persistant et de son comportement de base.
+- Implémentation de l'entrée/sortie automatique de l'arène et de la gestion de l'équipement.
 
 ## [2.6.0] - Setup du Mini-Foot
 - Ajout des commandes d'administration pour le Mini-Foot.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Le ballon est un **Slime** de taille 1 qui apparaît automatiquement au point d�
 Il est invulnérable, ne se déplace pas seul et reste plaqué au sol.
 S'il est détruit ou disparaît, il réapparaît au centre après quelques secondes.
 
+### Rejoindre et quitter une partie
+
+Marchez simplement dans l'arène pour rejoindre le match. Vous serez automatiquement placé dans l'équipe ayant le moins de joueurs (maximum 8 joueurs) et équipé d'une armure en cuir aux couleurs de votre équipe.
+
+Pour quitter la partie, sortez de la zone de l'arène : votre inventaire est nettoyé, les items du lobby vous sont rendus et le scoreboard du lobby réapparaît.
+
 ## 📦 Dépendances
 
 * **Requises :**

--- a/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
+++ b/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
@@ -20,6 +20,7 @@ import net.heneria.henerialobby.listener.InterfaceChatListener;
 import net.heneria.henerialobby.minifoot.MiniFootManager;
 import net.heneria.henerialobby.minifoot.MinifootAdminCommand;
 import net.heneria.henerialobby.minifoot.MinifootSelectionListener;
+import net.heneria.henerialobby.minifoot.MinifootGameListener;
 import net.heneria.henerialobby.scoreboard.ScoreboardManager;
 import net.heneria.henerialobby.tablist.TablistManager;
 import net.heneria.henerialobby.selector.ServerSelector;
@@ -158,6 +159,8 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
         }
         Bukkit.getPluginManager().registerEvents(new DisplayListener(this), this);
         Bukkit.getPluginManager().registerEvents(new MinifootSelectionListener(miniFootManager), this);
+        Bukkit.getPluginManager().registerEvents(new MinifootGameListener(this, miniFootManager), this);
+        Bukkit.getPluginManager().registerEvents(new MinifootGameListener(this, miniFootManager), this);
 
         if (getConfig().getBoolean("player-experience.player-visibility.enabled", true)) {
             visibilityManager = new VisibilityManager(this);
@@ -317,6 +320,7 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
         Bukkit.getPluginManager().registerEvents(new InterfaceChatListener(this), this);
         Bukkit.getPluginManager().registerEvents(new NPCListener(npcManager), this);
         Bukkit.getPluginManager().registerEvents(new MinifootSelectionListener(miniFootManager), this);
+        Bukkit.getPluginManager().registerEvents(new MinifootGameListener(this, miniFootManager), this);
 
         hologramManager = new HologramManager(this);
         HologramCommand hologramCommand = new HologramCommand(hologramManager);
@@ -379,6 +383,10 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
 
     public VisibilityManager getVisibilityManager() {
         return visibilityManager;
+    }
+
+    public MiniFootManager getMiniFootManager() {
+        return miniFootManager;
     }
 
 }

--- a/src/main/java/net/heneria/henerialobby/minifoot/MinifootGameListener.java
+++ b/src/main/java/net/heneria/henerialobby/minifoot/MinifootGameListener.java
@@ -1,0 +1,88 @@
+package net.heneria.henerialobby.minifoot;
+
+import net.heneria.henerialobby.HeneriaLobby;
+import net.heneria.henerialobby.selector.ServerSelector;
+import net.heneria.henerialobby.visibility.VisibilityManager;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class MinifootGameListener implements Listener {
+
+    private final HeneriaLobby plugin;
+    private final MiniFootManager manager;
+
+    public MinifootGameListener(HeneriaLobby plugin, MiniFootManager manager) {
+        this.plugin = plugin;
+        this.manager = manager;
+    }
+
+    @EventHandler
+    public void onMove(PlayerMoveEvent event) {
+        if (event.getTo() == null) return;
+        Player player = event.getPlayer();
+        boolean wasIn = manager.isPlaying(player);
+        boolean inArenaTo = manager.isInArena(event.getTo());
+        boolean inArenaFrom = manager.isInArena(event.getFrom());
+        if (!inArenaFrom && inArenaTo) {
+            if (manager.getTotalPlayers() >= 8) {
+                player.sendMessage("§cL'arène est pleine.");
+                player.teleport(event.getFrom());
+                return;
+            }
+            manager.handleEnter(player);
+        } else if (wasIn && !inArenaTo) {
+            manager.handleLeave(player);
+            giveLobbyItems(player);
+            plugin.updateDisplays(player);
+        }
+    }
+
+    private void giveLobbyItems(Player player) {
+        ServerSelector selector = plugin.getServerSelector();
+        player.getInventory().setItem(selector.getSelectorSlot(), selector.getSelectorItem());
+        VisibilityManager vm = plugin.getVisibilityManager();
+        if (vm != null) {
+            VisibilityManager.Mode mode = vm.getMode(player);
+            player.getInventory().setItem(vm.getSlot(), new ItemStack(vm.getMaterial(mode)));
+        }
+        player.updateInventory();
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) return;
+        if (!manager.isPlaying(player)) return;
+        ItemStack item = event.getCurrentItem();
+        if (item == null) return;
+        Material type = item.getType();
+        if (type == Material.LEATHER_HELMET || type == Material.LEATHER_CHESTPLATE
+                || type == Material.LEATHER_LEGGINGS || type == Material.LEATHER_BOOTS) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onDrop(PlayerDropItemEvent event) {
+        Player player = event.getPlayer();
+        if (!manager.isPlaying(player)) return;
+        Material type = event.getItemDrop().getItemStack().getType();
+        if (type == Material.LEATHER_HELMET || type == Material.LEATHER_CHESTPLATE
+                || type == Material.LEATHER_LEGGINGS || type == Material.LEATHER_BOOTS) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        Player player = event.getPlayer();
+        if (!manager.isPlaying(player)) return;
+        manager.handleLeave(player);
+    }
+}

--- a/src/main/java/net/heneria/henerialobby/scoreboard/ScoreboardManager.java
+++ b/src/main/java/net/heneria/henerialobby/scoreboard/ScoreboardManager.java
@@ -25,7 +25,7 @@ public class ScoreboardManager {
 
     public void updateAll() {
         for (Player player : Bukkit.getOnlinePlayers()) {
-            if (plugin.isLobbyWorld(player.getWorld())) {
+            if (plugin.isLobbyWorld(player.getWorld()) && (plugin.getMiniFootManager() == null || !plugin.getMiniFootManager().isPlaying(player))) {
                 update(player);
             } else {
                 var manager = Bukkit.getScoreboardManager();


### PR DESCRIPTION
## Summary
- allow players to join the Mini-Foot match by walking into the arena
- limit the arena to 8 players, auto assign team, gear and teleport
- restore lobby items and scoreboard when leaving

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68bddcc2b5008329be4c05be573c6de7