### PR TITLE
feat(minifoot): add ball push and physics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Implémentation du ballon persistant et de son comportement de base.
 - Implémentation de l'entrée/sortie automatique de l'arène et de la gestion de l'équipement.
+- Implémentation d'un système de physique avancée pour le ballon (poussée, glissade, rebond).
 
 ## [2.6.0] - Setup du Mini-Foot
 - Ajout des commandes d'administration pour le Mini-Foot.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ HeneriaLobby est un plugin de lobby tout-en-un conçu pour les serveurs Minecraf
 ### Ballon
 
 Le ballon est un **Slime** de taille 1 qui apparaît automatiquement au point défini.
-Il est invulnérable, ne se déplace pas seul et reste plaqué au sol.
+Les joueurs peuvent le pousser en courant dedans : il glisse progressivement sur le sol et rebondit sur les murs de l'arène.
 S'il est détruit ou disparaît, il réapparaît au centre après quelques secondes.
 
 ### Rejoindre et quitter une partie


### PR DESCRIPTION
## Summary
- allow players to push the minifoot ball with a short cooldown
- add glide and rebound physics to the ball
- document new ball behaviour

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bdde7d955083299fe36d8aecf66206