### PR TITLE
[MiniFoot] #5 - Logique de score et fin de partie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Implémentation du ballon persistant et de son comportement de base.
 - Implémentation de l'entrée/sortie automatique de l'arène et de la gestion de l'équipement.
 - Implémentation d'un système de physique avancée pour le ballon (poussée, glissade, rebond).
+- Finalisation de la logique de jeu : score, buts, fin de partie et amélioration de l'interface.
 
 ## [2.6.0] - Setup du Mini-Foot
 - Ajout des commandes d'administration pour le Mini-Foot.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ Marchez simplement dans l'arène pour rejoindre le match. Vous serez automatique
 
 Pour quitter la partie, sortez de la zone de l'arène : votre inventaire est nettoyé, les items du lobby vous sont rendus et le scoreboard du lobby réapparaît.
 
+### Règles du jeu
+
+* Deux équipes s'affrontent et tentent de marquer dans le but adverse.
+* Un but renvoie tous les joueurs à leur spawn et gèle la partie pendant 3 secondes.
+* La première équipe à atteindre **3 buts** remporte le match.
+* Une annonce de victoire est affichée et, 15 secondes plus tard, tous les joueurs sont expulsés de l'arène.
+
+### Configuration `minifoot.yml`
+
+Le fichier `minifoot.yml` contient les positions de l'arène, des buts, des spawns ainsi que la configuration du ballon :
+
+* `ball.push-force` – force appliquée au ballon lors d'une poussée (par défaut `1.0`).
+* `ball.friction` – coefficient de friction appliqué chaque tick pour ralentir le ballon (par défaut `0.96`).
+
 ## 📦 Dépendances
 
 * **Requises :**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,3 +1,3 @@
 # Roadmap
 
-- [x] Setup du Mini-Foot
+- [x] Mini-Jeu Mini-Foot (Terminé)

--- a/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
+++ b/src/main/java/net/heneria/henerialobby/HeneriaLobby.java
@@ -389,5 +389,9 @@ if (hdbPlugin != null && hdbPlugin instanceof HeadDatabaseAPI) {
         return miniFootManager;
     }
 
+    public SpawnManager getSpawnManager() {
+        return spawnManager;
+    }
+
 }
 

--- a/src/main/java/net/heneria/henerialobby/minifoot/MiniFootManager.java
+++ b/src/main/java/net/heneria/henerialobby/minifoot/MiniFootManager.java
@@ -10,6 +10,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Slime;
+import org.bukkit.Sound;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.metadata.FixedMetadataValue;
@@ -17,6 +18,9 @@ import org.bukkit.scoreboard.DisplaySlot;
 import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.util.Vector;
+import net.heneria.henerialobby.selector.ServerSelector;
+import net.heneria.henerialobby.visibility.VisibilityManager;
+import net.heneria.henerialobby.spawn.SpawnManager;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,6 +38,8 @@ public class MiniFootManager {
     private final java.util.Set<UUID> redTeam = new java.util.HashSet<>();
     private Slime ball;
     private int respawnCountdown = -1;
+    private int blueScore = 0;
+    private int redScore = 0;
 
     // Physics configuration
     private final double pushForce;
@@ -104,6 +110,27 @@ public class MiniFootManager {
     public boolean isInArena(Location loc) {
         Location pos1 = config.getLocation("arena.pos1");
         Location pos2 = config.getLocation("arena.pos2");
+        if (pos1 == null || pos2 == null || loc == null || loc.getWorld() == null) {
+            return false;
+        }
+        if (!loc.getWorld().equals(pos1.getWorld())) {
+            return false;
+        }
+        double minX = Math.min(pos1.getX(), pos2.getX());
+        double maxX = Math.max(pos1.getX(), pos2.getX());
+        double minY = Math.min(pos1.getY(), pos2.getY());
+        double maxY = Math.max(pos1.getY(), pos2.getY());
+        double minZ = Math.min(pos1.getZ(), pos2.getZ());
+        double maxZ = Math.max(pos1.getZ(), pos2.getZ());
+        return loc.getX() >= minX && loc.getX() <= maxX
+                && loc.getY() >= minY && loc.getY() <= maxY
+                && loc.getZ() >= minZ && loc.getZ() <= maxZ;
+    }
+
+    private boolean isInGoal(Team team, Location loc) {
+        String key = team == Team.BLUE ? "goal.blue" : "goal.red";
+        Location pos1 = config.getLocation(key + ".pos1");
+        Location pos2 = config.getLocation(key + ".pos2");
         if (pos1 == null || pos2 == null || loc == null || loc.getWorld() == null) {
             return false;
         }
@@ -192,6 +219,8 @@ public class MiniFootManager {
         redTeam.remove(id);
         player.getInventory().clear();
         player.getInventory().setArmorContents(new ItemStack[4]);
+        player.setWalkSpeed(0.2f);
+        player.setFlySpeed(0.1f);
         updateScoreboards();
     }
 
@@ -199,8 +228,9 @@ public class MiniFootManager {
         Scoreboard board = Bukkit.getScoreboardManager().getNewScoreboard();
         Objective obj = board.registerNewObjective("minifoot", "dummy", org.bukkit.ChatColor.GOLD + "Mini-Foot");
         obj.setDisplaySlot(DisplaySlot.SIDEBAR);
-        obj.getScore(org.bukkit.ChatColor.BLUE + "Bleus: " + org.bukkit.ChatColor.WHITE + blueTeam.size()).setScore(2);
-        obj.getScore(org.bukkit.ChatColor.RED + "Rouges: " + org.bukkit.ChatColor.WHITE + redTeam.size()).setScore(1);
+        obj.getScore(org.bukkit.ChatColor.BLUE + "Bleus: " + org.bukkit.ChatColor.WHITE + blueScore).setScore(3);
+        obj.getScore(org.bukkit.ChatColor.RED + "Rouges: " + org.bukkit.ChatColor.WHITE + redScore).setScore(2);
+        obj.getScore(org.bukkit.ChatColor.YELLOW + "Joueurs: " + org.bukkit.ChatColor.WHITE + getTotalPlayers()).setScore(1);
         for (UUID uuid : blueTeam) {
             Player p = Bukkit.getPlayer(uuid);
             if (p != null) {
@@ -213,6 +243,126 @@ public class MiniFootManager {
                 p.setScoreboard(board);
             }
         }
+    }
+
+    private java.util.List<Player> getPlayers() {
+        java.util.List<Player> players = new java.util.ArrayList<>();
+        for (UUID uuid : blueTeam) {
+            Player p = Bukkit.getPlayer(uuid);
+            if (p != null) {
+                players.add(p);
+            }
+        }
+        for (UUID uuid : redTeam) {
+            Player p = Bukkit.getPlayer(uuid);
+            if (p != null) {
+                players.add(p);
+            }
+        }
+        return players;
+    }
+
+    private void freezePlayers(boolean freeze) {
+        for (Player p : getPlayers()) {
+            if (freeze) {
+                p.setWalkSpeed(0f);
+                p.setFlySpeed(0f);
+            } else {
+                p.setWalkSpeed(0.2f);
+                p.setFlySpeed(0.1f);
+            }
+        }
+    }
+
+    private void giveLobbyItems(Player player) {
+        ServerSelector selector = plugin.getServerSelector();
+        player.getInventory().setItem(selector.getSelectorSlot(), selector.getSelectorItem());
+        VisibilityManager vm = plugin.getVisibilityManager();
+        if (vm != null) {
+            VisibilityManager.Mode mode = vm.getMode(player);
+            player.getInventory().setItem(vm.getSlot(), new ItemStack(vm.getMaterial(mode)));
+        }
+        player.updateInventory();
+    }
+
+    private void startCountdown(Runnable end) {
+        freezePlayers(true);
+        for (int i = 3; i > 0; i--) {
+            final int sec = i;
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                for (Player p : getPlayers()) {
+                    p.sendTitle(org.bukkit.ChatColor.GOLD + String.valueOf(sec), "", 0, 20, 0);
+                }
+            }, (3 - i) * 20L);
+        }
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            freezePlayers(false);
+            end.run();
+        }, 60L);
+    }
+
+    private void handleGoal(Team scoringTeam) {
+        if (scoringTeam == Team.BLUE) {
+            blueScore++;
+        } else {
+            redScore++;
+        }
+        updateScoreboards();
+        for (Player p : getPlayers()) {
+            p.playSound(p.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1f, 1f);
+            p.sendTitle(org.bukkit.ChatColor.GOLD + "But !", (scoringTeam == Team.BLUE ? org.bukkit.ChatColor.BLUE : org.bukkit.ChatColor.RED) + "Équipe " + (scoringTeam == Team.BLUE ? "Bleue" : "Rouge"), 10, 40, 10);
+            Team team = blueTeam.contains(p.getUniqueId()) ? Team.BLUE : Team.RED;
+            Location spawn = getSpawn(team);
+            if (spawn != null) {
+                p.teleport(spawn);
+            }
+        }
+        if (ball != null) {
+            Location spawn = getBallSpawn();
+            if (spawn != null) {
+                ball.teleport(spawn);
+                ball.setVelocity(new Vector());
+            }
+        }
+        Team winner = null;
+        if (blueScore >= 3) {
+            winner = Team.BLUE;
+        }
+        if (redScore >= 3) {
+            winner = Team.RED;
+        }
+        Team winTeam = winner;
+        startCountdown(() -> {
+            if (winTeam != null) {
+                announceVictory(winTeam);
+            }
+        });
+    }
+
+    private void announceVictory(Team team) {
+        for (Player p : getPlayers()) {
+            p.sendTitle(org.bukkit.ChatColor.GOLD + "Victoire !", (team == Team.BLUE ? org.bukkit.ChatColor.BLUE : org.bukkit.ChatColor.RED) + "Équipe " + (team == Team.BLUE ? "Bleue" : "Rouge"), 10, 60, 10);
+        }
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            for (Player p : new java.util.ArrayList<>(getPlayers())) {
+                handleLeave(p);
+                giveLobbyItems(p);
+                plugin.updateDisplays(p);
+                SpawnManager sm = plugin.getSpawnManager();
+                if (sm != null && sm.hasSpawn()) {
+                    sm.teleport(p);
+                } else {
+                    p.teleport(p.getWorld().getSpawnLocation());
+                }
+            }
+            blueScore = 0;
+            redScore = 0;
+            updateScoreboards();
+            if (ball != null) {
+                ball.remove();
+                ball = null;
+            }
+        }, 15 * 20L);
     }
 
     private void spawnBall() {
@@ -255,6 +405,16 @@ public class MiniFootManager {
                 return;
             }
 
+            Location loc = ball.getLocation();
+            if (isInGoal(Team.BLUE, loc)) {
+                handleGoal(Team.RED);
+                return;
+            }
+            if (isInGoal(Team.RED, loc)) {
+                handleGoal(Team.BLUE);
+                return;
+            }
+
             Vector vel = ball.getVelocity();
 
             if (ball.isOnGround() && vel.getY() != 0) {
@@ -267,7 +427,6 @@ public class MiniFootManager {
 
             Location pos1 = config.getLocation("arena.pos1");
             Location pos2 = config.getLocation("arena.pos2");
-            Location loc = ball.getLocation();
             if (pos1 != null && pos2 != null) {
                 double minX = Math.min(pos1.getX(), pos2.getX());
                 double maxX = Math.max(pos1.getX(), pos2.getX());

--- a/src/main/resources/minifoot.yml
+++ b/src/main/resources/minifoot.yml
@@ -6,3 +6,6 @@ spawn:
   blue: {}
   red: {}
 ballspawn: {}
+ball:
+  push-force: 1.0
+  friction: 0.96


### PR DESCRIPTION
## Summary
- implémente la détection des buts, le comptage des scores et la fin de partie avec annonce de victoire
- gèle les joueurs après chaque but, téléporte les équipes à leur spawn et remet le ballon au centre
- ajoute la configuration de la physique du ballon et met à jour la documentation (règles, changelog, roadmap)

## Testing
- `mvn -q -e -DskipTests package` *(échoue : Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bddf948b8c8329a46db42880b84ff9